### PR TITLE
Fix stale provider client/thread after a Claude or Codex account switch

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -34512,14 +34512,30 @@ async def run_claude_sdk(
         )
         return
     except Exception as exc:
+        # A client that fails before its first query (for example, credentials
+        # changed on disk after the client was created) would otherwise stay
+        # cached and keep failing the same way for every following turn until
+        # it ages out at CLAUDE_SDK_IDLE_TTL_SECONDS. Evict it immediately so
+        # the next turn starts a fresh client against whatever is currently
+        # authenticated, instead of silently reusing the stale one.
+        startup_ownership_token = str(
+            startup_active.get("claude_sdk_owner_token") or ""
+        )
+        if startup_ownership_token and await turn_slot_is_owned(
+            session_id,
+            run_id,
+        ):
+            await evict_claude_sdk_chat(
+                session_id,
+                force=True,
+                manager=manager,
+                ownership_token=startup_ownership_token,
+            )
         await finish_claude_sdk_start_failure(
             session_id,
             run_id,
             f"Claude SDK could not start: {concise_error_message(exc)}",
-            ownership_token=(
-                str(startup_active.get("claude_sdk_owner_token") or "")
-                or None
-            ),
+            ownership_token=startup_ownership_token or None,
         )
         return
 

--- a/agent_server.py
+++ b/agent_server.py
@@ -30227,23 +30227,39 @@ async def evict_codex_app_server_thread(
 async def unpin_codex_app_server_thread(
     manager: CodexAppServerManager,
     thread_id: str,
+    *,
+    force: bool = False,
 ) -> None:
+    """Release one pin; evict only once nothing else needs the thread.
+
+    ``force=True`` skips the "does some chat still reference this thread"
+    keep-alive check. Use it when the caller already knows the thread is
+    broken (for example, a turn/start rejection during the codex-exec
+    fallback path) - the owning chat's own session record almost always
+    still points at that exact thread_id, since that record is what made
+    it "this chat's thread" in the first place. Without force, that would
+    always read as "still retained" and keep the known-bad thread cached
+    for the next turn to fail against again, instead of being evicted.
+    evict_codex_app_server_thread() still declines if the thread has a
+    genuinely active turn, so this cannot evict work in flight elsewhere.
+    """
     if not thread_id:
         return
     async with CODEX_APP_SERVER_THREAD_LRU_LOCK:
         count = CODEX_APP_SERVER_THREAD_PIN_COUNTS.get(thread_id, 0)
-        if count > 1:
+        if count > 1 and not force:
             CODEX_APP_SERVER_THREAD_PIN_COUNTS[thread_id] = count - 1
             return
         CODEX_APP_SERVER_THREAD_PIN_COUNTS.pop(thread_id, None)
         CODEX_APP_SERVER_PINNED_THREADS.discard(thread_id)
-    retained = any(
-        str(session_provider_id(session) or "") == thread_id
-        for session in STORE.sessions.values()
-    )
-    if retained:
-        await touch_codex_app_server_thread(manager, thread_id)
-        return
+    if not force:
+        retained = any(
+            str(session_provider_id(session) or "") == thread_id
+            for session in STORE.sessions.values()
+        )
+        if retained:
+            await touch_codex_app_server_thread(manager, thread_id)
+            return
     async with CODEX_APP_SERVER_THREAD_LRU_LOCK:
         CODEX_APP_SERVER_THREAD_LRU.pop(thread_id, None)
     await evict_codex_app_server_thread(
@@ -38001,7 +38017,14 @@ async def run_codex_app_server(
             if turn is not None:
                 await turn.close()
             if thread_pinned and provider_id:
-                await unpin_codex_app_server_thread(manager, provider_id)
+                # force=True: this thread just failed to start a turn, so
+                # it must not be kept alive for the next one to fail against
+                # again just because this chat's own session still names it.
+                await unpin_codex_app_server_thread(
+                    manager,
+                    provider_id,
+                    force=True,
+                )
                 thread_pinned = False
             cleared = await clear_active_process(
                 session_id,

--- a/test_claude_sdk_runner.py
+++ b/test_claude_sdk_runner.py
@@ -231,6 +231,40 @@ class FakeClaudeManager:
         return self.loaded and chat_id == "chat-claude"
 
 
+class FakeClaudeManagerFailingAfterOwnership(FakeClaudeManager):
+    """A reused supervisor that registers ownership, then fails to deliver.
+
+    Models a stale client picked up from the cache (for example, one whose
+    backing CLI process authenticated under an account that was since
+    switched out): the chat is claimed via ``on_supervisor_ready`` exactly
+    like a healthy start, but the delivery call itself then raises something
+    other than ``ClaudeSDKQueryError``.
+    """
+
+    def __init__(self, error: BaseException) -> None:
+        super().__init__()
+        self.error = error
+
+    async def start_run(
+        self,
+        chat_id: str,
+        prompt: str,
+        *,
+        run_id: str,
+        options: object,
+        configuration_key: str,
+        query_session_id: str | None = None,
+        on_supervisor_ready: object | None = None,
+    ) -> FakeClaudeRun:
+        self.start_calls.append(
+            (chat_id, prompt, run_id, options, configuration_key, query_session_id)
+        )
+        self.active_run_id = run_id
+        if on_supervisor_ready is not None:
+            await on_supervisor_ready(self.owner_token)  # type: ignore[operator]
+        raise self.error
+
+
 class SequencedClaudeManager(FakeClaudeManager):
     def __init__(self, handles: list[FakeClaudeRun]) -> None:
         super().__init__(handles[0])
@@ -3775,6 +3809,106 @@ class ClaudeSDKRunnerTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(any(
             call.args[1] == "error"
             and "replay ACK missing" in call.args[2]["message"]
+            for call in append_event.await_args_list
+        ))
+
+    async def test_reused_client_generic_start_failure_evicts_stale_client(
+        self,
+    ) -> None:
+        """A non-ClaudeSDKQueryError start failure must not leave a stale
+        client cached. Regression test: previously only ClaudeSDKQueryError
+        triggered eviction here, so a client that failed for any other
+        reason immediately after claiming ownership (for example, one whose
+        backing CLI process authenticated under an account that was since
+        switched out) stayed cached and kept failing the same way on every
+        following turn until it aged out after CLAUDE_SDK_IDLE_TTL_SECONDS.
+        """
+
+        manager = FakeClaudeManagerFailingAfterOwnership(
+            RuntimeError("client not authenticated")
+        )
+        append_event = AsyncMock(return_value={})
+        append_finished = AsyncMock(return_value={})
+        project = AsyncMock()
+
+        with patch.object(
+            agent_server,
+            "resolve_claude_resume_provider",
+            return_value=(None, None),
+        ), patch.object(
+            agent_server,
+            "capture_git_baseline",
+            AsyncMock(return_value={"head": "base"}),
+        ), patch.object(
+            agent_server,
+            "build_claude_sdk_options",
+            return_value=(object(), "config", "/usr/bin/claude"),
+        ), patch.object(
+            agent_server,
+            "claude_sdk_manager",
+            AsyncMock(return_value=manager),
+        ), patch.object(
+            agent_server,
+            "watch_manifest_artifacts",
+            wait_forever,
+        ), patch.object(
+            agent_server,
+            "append_event",
+            append_event,
+        ), patch.object(
+            agent_server,
+            "project_claude_sdk_message",
+            project,
+        ), patch.object(
+            agent_server,
+            "cancel_claude_interactions",
+            AsyncMock(),
+        ), patch.object(
+            agent_server,
+            "collect_manifest",
+            AsyncMock(),
+        ), patch.object(
+            agent_server,
+            "collect_recent_leftover_manifests",
+            AsyncMock(),
+        ), patch.object(
+            agent_server,
+            "append_turn_finished_event",
+            append_finished,
+        ), patch.object(
+            agent_server,
+            "release_turn_slot",
+            AsyncMock(return_value=True),
+        ), patch.object(
+            agent_server,
+            "record_runtime_failure",
+            Mock(),
+        ), patch.object(
+            agent_server,
+            "should_schedule_queue_after_finish",
+            return_value=False,
+        ), patch.object(
+            agent_server,
+            "schedule_next_queued_turn",
+            Mock(),
+        ):
+            await agent_server.run_claude_sdk(
+                "chat-claude",
+                "run-claude",
+                "Prompt",
+                dict(self.session),
+                Path(self.cwd) / ".manifest.json",
+            )
+
+        self.assertEqual(len(manager.start_calls), 1)
+        self.assertEqual(manager.evict_calls, [("chat-claude", True)])
+        project.assert_not_awaited()
+        terminal = append_finished.await_args.args[1]
+        self.assertIsNone(terminal["exit_code"])
+        self.assertEqual(terminal["result_text"], "")
+        self.assertTrue(any(
+            call.args[1] == "error"
+            and "client not authenticated" in call.args[2]["message"]
             for call in append_event.await_args_list
         ))
 

--- a/test_codex_app_server_runner.py
+++ b/test_codex_app_server_runner.py
@@ -213,6 +213,22 @@ class FakeManager:
         return []
 
 
+class FakeThreadEvictionManager:
+    """Minimal manager double for unpin/evict_codex_app_server_thread only."""
+
+    def __init__(self) -> None:
+        self.unsubscribe_calls: list[str] = []
+
+    def active_turn(self, thread_id: str) -> object | None:
+        return None
+
+    def is_thread_loaded(self, thread_id: str) -> bool:
+        return True
+
+    async def unsubscribe_thread(self, thread_id: str) -> None:
+        self.unsubscribe_calls.append(thread_id)
+
+
 def completed_notification(status: str = "completed") -> dict[str, object]:
     return {
         "method": "turn/completed",
@@ -1033,6 +1049,63 @@ class CodexAppServerRunnerTests(unittest.IsolatedAsyncioTestCase):
             fallback_events[0]["from"],
             agent_server.CODEX_TRANSPORT_APP_SERVER,
         )
+
+    async def _unpin_native_thread_with_clean_registry(
+        self,
+        manager: "FakeThreadEvictionManager",
+        *,
+        force: bool,
+    ) -> None:
+        previous_lru = agent_server.CODEX_APP_SERVER_THREAD_LRU
+        previous_pinned = agent_server.CODEX_APP_SERVER_PINNED_THREADS
+        previous_pin_counts = agent_server.CODEX_APP_SERVER_THREAD_PIN_COUNTS
+        previous_evicting = agent_server.CODEX_APP_SERVER_EVICTING_THREADS
+        agent_server.CODEX_APP_SERVER_THREAD_LRU = OrderedDict()
+        agent_server.CODEX_APP_SERVER_PINNED_THREADS = set()
+        agent_server.CODEX_APP_SERVER_THREAD_PIN_COUNTS = {}
+        agent_server.CODEX_APP_SERVER_EVICTING_THREADS = {}
+        try:
+            # self.session (the sole entry in STORE.sessions from
+            # asyncSetUp) already has codex_thread_id == "thread-native", so
+            # this chat "retains" its own thread the same way it would for
+            # the real failing chat in the account-switch scenario.
+            await agent_server.unpin_codex_app_server_thread(
+                manager, "thread-native", force=force
+            )
+        finally:
+            agent_server.CODEX_APP_SERVER_THREAD_LRU = previous_lru
+            agent_server.CODEX_APP_SERVER_PINNED_THREADS = previous_pinned
+            agent_server.CODEX_APP_SERVER_THREAD_PIN_COUNTS = previous_pin_counts
+            agent_server.CODEX_APP_SERVER_EVICTING_THREADS = previous_evicting
+
+    async def test_unpin_keeps_a_thread_still_referenced_by_its_own_chat(
+        self,
+    ) -> None:
+        """Unchanged existing behavior: a normal (non-forced) unpin at the
+        end of a successful turn must NOT evict a thread its own chat still
+        points at - otherwise every ordinary turn would tear down and
+        reconnect the persistent thread it just used.
+        """
+
+        manager = FakeThreadEvictionManager()
+        await self._unpin_native_thread_with_clean_registry(manager, force=False)
+        self.assertEqual(manager.unsubscribe_calls, [])
+
+    async def test_forced_unpin_evicts_a_thread_still_referenced_by_its_own_chat(
+        self,
+    ) -> None:
+        """Regression test for the account-switch bug report: a Codex chat's
+        own persisted thread_id must not block a forced eviction. Without
+        force=True, this reads as "still retained" (the failing chat's own
+        session record is exactly what names that thread_id) and the
+        known-bad thread stays cached for the next turn to fail against
+        again - which is what run_codex_app_server's codex-exec fallback
+        path now opts out of with force=True after a turn/start rejection.
+        """
+
+        manager = FakeThreadEvictionManager()
+        await self._unpin_native_thread_with_clean_registry(manager, force=True)
+        self.assertEqual(manager.unsubscribe_calls, ["thread-native"])
 
     async def test_ambiguous_post_send_failure_never_replays_through_exec(self) -> None:
         pending_turn = FakeTurn(


### PR DESCRIPTION
## Summary
User report: switching or signing out of a Codex or Claude Code account made a chat feel like it needed a server restart. The server process, the AgentsDock connection, and every other chat were never actually affected (each turn runs as an isolated `asyncio.create_task` via `supervise_provider_turn_task`) - but the persistent per-chat provider connection for the affected chat could stay stuck on stale/broken credentials.

Two separate root causes, one per provider:

- **Claude**: `run_claude_sdk` reuses a cached, chat-owned `ClaudeSDKClient` (idle-retained for `CLAUDE_SDK_IDLE_TTL_SECONDS`). Only `ClaudeSDKQueryError` triggered eviction of a broken client on start failure; any other exception type left the same known-broken client cached, failing the same way on every following turn until it aged out or the server restarted.
- **Codex**: `run_codex_app_server`'s codex-exec fallback (which already retries the same turn transparently on some failures) calls `unpin_codex_app_server_thread` after a `turn/start` rejection - but that function only evicts a thread once nothing in `STORE.sessions` still references it. The failing chat's own session record is exactly what names that thread_id, so it always read as "still retained" and the known-bad thread was kept warm instead of evicted.

## User-facing result
Worst case is now "the first message on that chat fails once, then it just works" - not a multi-minute stall or a server restart. Nothing else (the server process, the AgentsDock connection, other chats) was ever actually affected.

## Changes
- `agent_server.py`: broaden Claude's generic `except Exception` start-failure branch to evict, mirroring the existing `ClaudeSDKQueryError` handling. Add `force=True` to `unpin_codex_app_server_thread` to skip its keep-alive check, used only at the turn/start-rejection fallback call site; every other call site is unchanged. `evict_codex_app_server_thread` still declines if the thread has a genuinely active turn elsewhere, so `force` cannot tear down work in flight on another chat.
- Regression tests for both: each fails against the pre-fix code and passes after, verified directly (not against mocks) for the Codex thread-retention check.

## Test plan
- [x] New regression tests fail on the pre-fix code, pass after (verified both ways for each fix)
- [x] `test_claude_sdk_runner.py`, `test_claude_sdk_client.py`, `test_codex_app_server_runner.py`, `test_codex_app_server.py`, `test_codex_controls.py`, `test_turn_restart_recovery.py`, `test_queue_steer.py`, `test_provider_authority_lifecycle.py`, `test_server_restart_endpoints.py` - all pass (407+ tests, no regressions)
- [x] `python3 -m py_compile agent_server.py`