### PR TITLE
Add local session discovery and bulk-import for Claude Code and Codex

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -189,6 +189,9 @@ SERVER_UPDATE_PUBLIC_KEY = SERVER_ROOT / "release-public-key.pem"
 SERVER_UPDATE_RUNNER = SERVER_ROOT / "update_runner.py"
 CLAUDE_PROJECTS_ROOT = Path(os.environ.get("CLAUDE_PROJECTS_ROOT", Path.home() / ".claude" / "projects"))
 CODEX_SESSIONS_ROOT = Path(os.environ.get("CODEX_SESSIONS_ROOT", Path.home() / ".codex" / "sessions"))
+CODEX_SESSION_INDEX_PATH = (
+    Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))).expanduser() / "session_index.jsonl"
+)
 CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
 CODEX_BIN = os.environ.get("CODEX_BIN", "codex")
 CODEX_DEFAULT_MODEL = agentsdock_setting("CODEX_MODEL", "gpt-5.5").strip() or "gpt-5.5"
@@ -668,6 +671,10 @@ Scheduled jobs:
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def iso_from_timestamp(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 VALID_JOB_SCHEDULE_KINDS = {"interval", "cron", "rrule"}
@@ -3280,6 +3287,20 @@ class CreateSessionRequest(BaseModel):
     codex_approvals_reviewer: Literal["user", "auto_review", "guardian_subagent"] | None = None
     provider_jobs_access: Literal["full", "read_only", "blocked"] | None = None
     import_history: bool | None = None
+
+
+MAX_BULK_IMPORT_ITEMS = 25
+
+
+class BulkImportSessionItem(BaseModel):
+    provider_session_id: str
+    backend: str
+    cwd: str | None = None
+    title: str | None = None
+
+
+class BulkImportSessionsRequest(BaseModel):
+    items: list[BulkImportSessionItem]
 
 
 class UpdateSessionRequest(BaseModel):
@@ -24941,6 +24962,7 @@ def is_import_boilerplate(text: str) -> bool:
         "<environment_context>",
         "<permissions instructions>",
         "<collaboration_mode>",
+        "<recommended_plugins>",
         "# AGENTS.md instructions",
         "# Context from my IDE setup:",
     )
@@ -25071,6 +25093,44 @@ def claude_transcript_matches_cwd(path: Path, cwd: str) -> bool:
             if recorded_cwd and str(Path(str(recorded_cwd)).expanduser()) == expected_cwd:
                 return True
     return False
+
+
+def claude_transcript_cwd(path: Path) -> str | None:
+    """Recover the working directory Claude recorded for a transcript, if any."""
+
+    for region in bounded_claude_transcript_regions(path):
+        for raw_line in region.splitlines():
+            if not raw_line or len(raw_line) > CLAUDE_TRANSCRIPT_CWD_LINE_BYTES:
+                continue
+            try:
+                event = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            recorded_cwd = event.get("cwd") if isinstance(event, dict) else None
+            if recorded_cwd:
+                return str(recorded_cwd)
+    return None
+
+
+def claude_transcript_preview(path: Path) -> str | None:
+    """Return a short snippet of the first user message, for a local-session label."""
+
+    region = next(bounded_claude_transcript_regions(path), None)
+    if not region:
+        return None
+    for raw_line in region.splitlines():
+        if not raw_line or len(raw_line) > CLAUDE_TRANSCRIPT_CWD_LINE_BYTES:
+            continue
+        try:
+            event = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(event, dict) or event.get("type") != "user":
+            continue
+        text = compact_import_text(strip_agentsdock_generated_user_text(message_text(event.get("message"))))
+        if text and not is_import_boilerplate(text):
+            return text[:160]
+    return None
 
 
 def claude_project_dir_for_cwd(cwd: str) -> Path:
@@ -25332,6 +25392,160 @@ def session_provider_id(sess: dict[str, Any]) -> str | None:
     if backend == BACKEND_CODEX:
         return sess.get("codex_thread_id") or sess.get("session_id")
     return sess.get("session_id")
+
+
+def local_claude_session_candidates(known_provider_ids: set[str]) -> list[dict[str, Any]]:
+    if not CLAUDE_PROJECTS_ROOT.exists():
+        return []
+    candidates: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for path in CLAUDE_PROJECTS_ROOT.rglob("*.jsonl"):
+        provider_id = path.stem
+        if not provider_id or provider_id in seen_ids or provider_id in known_provider_ids:
+            continue
+        seen_ids.add(provider_id)
+        with suppress(OSError):
+            mtime = path.stat().st_mtime
+            cwd = claude_transcript_cwd(path)
+            preview = claude_transcript_preview(path)
+            folder_display = Path(cwd).name if cwd else path.parent.name
+            label = f"{folder_display}: {preview}" if preview else (folder_display or f"Claude chat {provider_id[:8]}")
+            candidates.append({
+                "provider_session_id": provider_id,
+                "backend": BACKEND_CLAUDE,
+                "label": label,
+                "updated_at": iso_from_timestamp(mtime),
+                "cwd": cwd,
+            })
+    return candidates
+
+
+CODEX_TRANSCRIPT_SCAN_LINES = 200
+
+
+def codex_transcript_meta(path: Path) -> tuple[str | None, str | None]:
+    """Return (session_id, cwd) from a Codex transcript's session_meta record."""
+    with suppress(OSError):
+        with path.open("r", encoding="utf-8", errors="ignore") as stream:
+            for _ in range(CODEX_TRANSCRIPT_SCAN_LINES):
+                line = stream.readline()
+                if not line:
+                    break
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if not isinstance(event, dict) or event.get("type") != "session_meta":
+                    continue
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                session_id = payload.get("id") or payload.get("session_id")
+                cwd = payload.get("cwd")
+                return (str(session_id) if session_id else None, str(cwd) if cwd else None)
+    return None, None
+
+
+def codex_transcript_preview(path: Path) -> str | None:
+    """Return a short snippet of the first user message, for a local-session label."""
+    with suppress(OSError):
+        with path.open("r", encoding="utf-8", errors="ignore") as stream:
+            for _ in range(CODEX_TRANSCRIPT_SCAN_LINES):
+                line = stream.readline()
+                if not line:
+                    break
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                event_type = event.get("type")
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                text: str | None = None
+                if event_type == "event_msg" and payload.get("type") == "user_message":
+                    text = str(payload.get("message") or "")
+                elif event_type == "response_item" and payload.get("type") == "message" and payload.get("role") == "user":
+                    text = text_from_content(payload.get("content"))
+                if not text:
+                    continue
+                text = compact_import_text(strip_agentsdock_generated_user_text(text))
+                if text and not is_import_boilerplate(text):
+                    return text[:160]
+    return None
+
+
+def codex_session_index_thread_names() -> dict[str, str]:
+    """Best-effort id -> human title map. Not authoritative: many real Codex
+
+    sessions (including every ``codex exec`` run) never get an entry here, so
+    this is only used to prefer a nicer label, never to decide what counts as
+    a session — that comes from scanning the transcripts themselves.
+    """
+    names: dict[str, str] = {}
+    if not CODEX_SESSION_INDEX_PATH.exists():
+        return names
+    with suppress(OSError):
+        with CODEX_SESSION_INDEX_PATH.open("r", encoding="utf-8", errors="ignore") as stream:
+            for line in stream:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                provider_id = str(entry.get("id") or "").strip()
+                thread_name = str(entry.get("thread_name") or "").strip()
+                if provider_id and thread_name:
+                    names[provider_id] = thread_name
+    return names
+
+
+def local_codex_session_candidates(known_provider_ids: set[str]) -> list[dict[str, Any]]:
+    if not CODEX_SESSIONS_ROOT.exists():
+        return []
+    thread_names = codex_session_index_thread_names()
+    candidates: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for path in CODEX_SESSIONS_ROOT.rglob("*.jsonl"):
+        provider_id, cwd = codex_transcript_meta(path)
+        if not provider_id or provider_id in seen_ids or provider_id in known_provider_ids:
+            continue
+        seen_ids.add(provider_id)
+        with suppress(OSError):
+            mtime = path.stat().st_mtime
+            label = thread_names.get(provider_id)
+            if not label:
+                preview = codex_transcript_preview(path)
+                folder_display = Path(cwd).name if cwd else path.stem
+                label = f"{folder_display}: {preview}" if preview else (folder_display or f"Codex chat {provider_id[:8]}")
+            candidates.append({
+                "provider_session_id": provider_id,
+                "backend": BACKEND_CODEX,
+                "label": label,
+                "updated_at": iso_from_timestamp(mtime),
+                "cwd": cwd,
+            })
+    return candidates
+
+
+def local_session_candidates(limit: int) -> list[dict[str, Any]]:
+    """Enumerate local Claude/Codex sessions not already imported into AgentsDock."""
+
+    known_provider_ids = {
+        pid for pid in (session_provider_id(sess) for sess in STORE.sessions.values()) if pid
+    }
+    candidates = [
+        *local_claude_session_candidates(known_provider_ids),
+        *local_codex_session_candidates(known_provider_ids),
+    ]
+    candidates.sort(key=lambda c: c["updated_at"], reverse=True)
+    return candidates[:limit]
 
 
 def standalone_provider_session(sess: dict[str, Any]) -> dict[str, Any]:
@@ -42858,6 +43072,55 @@ async def create_session(req: CreateSessionRequest) -> dict[str, Any]:
     if should_import:
         await import_session_history(sess)
     return {"session": public_session(sess)}
+
+
+@app.get("/api/local-sessions")
+async def get_local_sessions(
+    limit: int = Query(default=200, ge=1, le=500),
+) -> dict[str, Any]:
+    """List local Claude/Codex chat history not yet imported into AgentsDock."""
+
+    sessions = await asyncio.to_thread(local_session_candidates, limit)
+    return {"sessions": sessions}
+
+
+@app.post("/api/sessions/bulk-import")
+async def bulk_import_sessions(req: BulkImportSessionsRequest) -> dict[str, Any]:
+    if not req.items:
+        raise HTTPException(status_code=400, detail="items must not be empty")
+    if len(req.items) > MAX_BULK_IMPORT_ITEMS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"at most {MAX_BULK_IMPORT_ITEMS} items are allowed per bulk import",
+        )
+    results: list[dict[str, Any]] = []
+    for item in req.items:
+        try:
+            create_req = CreateSessionRequest(
+                backend=item.backend,
+                provider_session_id=item.provider_session_id,
+                cwd=item.cwd,
+                title=item.title,
+            )
+            sess = await STORE.create(create_req)
+            await import_session_history(sess)
+            results.append({
+                "provider_session_id": item.provider_session_id,
+                "session_id": sess["id"],
+                "ok": True,
+            })
+        except Exception as exc:
+            results.append({
+                "provider_session_id": item.provider_session_id,
+                "session_id": None,
+                "ok": False,
+                "error": concise_error_message(exc),
+            })
+        # Yield between items so a large batch doesn't monopolize the event
+        # loop for its entire duration (import_session_history itself still
+        # does blocking file I/O inline; this bounds exposure, it doesn't fix it).
+        await asyncio.sleep(0)
+    return {"results": results}
 
 
 @app.get("/api/sessions/{session_id}/timeline-index")

--- a/test_local_sessions_import.py
+++ b/test_local_sessions_import.py
@@ -1,0 +1,266 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import agent_server
+
+
+def write_claude_transcript(path: Path, *, cwd: str | None, first_user_text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    if cwd is not None:
+        lines.append(json.dumps({"type": "user", "cwd": cwd, "message": {"role": "user", "content": first_user_text}}))
+    else:
+        lines.append(json.dumps({"type": "user", "message": {"role": "user", "content": first_user_text}}))
+    path.write_text("\n".join(lines) + "\n")
+
+
+class LocalClaudeSessionCandidatesTests(unittest.TestCase):
+    def test_reads_cwd_and_first_message_into_label(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            projects_root = Path(temporary) / "claude-projects"
+            transcript = projects_root / "-Users-georgia-code-widget" / "claude-abc123.jsonl"
+            write_claude_transcript(transcript, cwd="/Users/georgia/code/widget", first_user_text="Fix the flaky test")
+
+            with patch.object(agent_server, "CLAUDE_PROJECTS_ROOT", projects_root):
+                candidates = agent_server.local_claude_session_candidates(set())
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate["provider_session_id"], "claude-abc123")
+        self.assertEqual(candidate["backend"], agent_server.BACKEND_CLAUDE)
+        self.assertEqual(candidate["cwd"], "/Users/georgia/code/widget")
+        self.assertIn("widget", candidate["label"])
+        self.assertIn("Fix the flaky test", candidate["label"])
+
+    def test_dedups_against_already_imported_provider_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            projects_root = Path(temporary) / "claude-projects"
+            transcript = projects_root / "-Users-georgia-code-widget" / "claude-abc123.jsonl"
+            write_claude_transcript(transcript, cwd="/Users/georgia/code/widget", first_user_text="Fix the flaky test")
+
+            with patch.object(agent_server, "CLAUDE_PROJECTS_ROOT", projects_root):
+                candidates = agent_server.local_claude_session_candidates({"claude-abc123"})
+
+        self.assertEqual(candidates, [])
+
+    def test_falls_back_to_folder_name_when_transcript_has_no_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            projects_root = Path(temporary) / "claude-projects"
+            transcript = projects_root / "-unexpected-project-name" / "claude-xyz789.jsonl"
+            write_claude_transcript(transcript, cwd=None, first_user_text="")
+
+            with patch.object(agent_server, "CLAUDE_PROJECTS_ROOT", projects_root):
+                candidates = agent_server.local_claude_session_candidates(set())
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertIsNone(candidate["cwd"])
+        self.assertIn("-unexpected-project-name", candidate["label"])
+
+    def test_missing_projects_root_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            missing_root = Path(temporary) / "does-not-exist"
+            with patch.object(agent_server, "CLAUDE_PROJECTS_ROOT", missing_root):
+                candidates = agent_server.local_claude_session_candidates(set())
+        self.assertEqual(candidates, [])
+
+
+def write_codex_transcript(path: Path, *, session_id: str, cwd: str, first_user_text: str | None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps({
+        "timestamp": "2026-08-23T00:00:00.000Z",
+        "type": "session_meta",
+        "payload": {"id": session_id, "session_id": session_id, "cwd": cwd}
+    })]
+    if first_user_text is not None:
+        lines.append(json.dumps({
+            "timestamp": "2026-08-23T00:00:01.000Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": first_user_text}
+        }))
+    path.write_text("\n".join(lines) + "\n")
+
+
+class LocalCodexSessionCandidatesTests(unittest.TestCase):
+    def test_skips_the_injected_recommended_plugins_turn_to_find_the_real_prompt(self) -> None:
+        # codex CLI injects a synthetic first user-role turn carrying
+        # <recommended_plugins> + <environment_context> before the real
+        # prompt. Regression coverage for that turn leaking into the label.
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions_root = Path(temporary) / "codex-sessions"
+            transcript = sessions_root / "2026" / "08" / "23" / "rollout-plugins.jsonl"
+            transcript.parent.mkdir(parents=True)
+            lines = [
+                json.dumps({
+                    "type": "session_meta",
+                    "payload": {"id": "session-with-plugins-turn", "cwd": "/work/octopus-facts"}
+                }),
+                json.dumps({
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "<recommended_plugins>\nSome plugin list...\n</recommended_plugins>"},
+                            {"type": "input_text", "text": "<environment_context>\n  <cwd>/work/octopus-facts</cwd>\n</environment_context>"}
+                        ]
+                    }
+                }),
+                json.dumps({
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Tell me one fun fact about octopuses."}]
+                    }
+                })
+            ]
+            transcript.write_text("\n".join(lines) + "\n")
+            missing_index = Path(temporary) / "session_index.jsonl"
+
+            with patch.object(agent_server, "CODEX_SESSIONS_ROOT", sessions_root), patch.object(
+                agent_server, "CODEX_SESSION_INDEX_PATH", missing_index
+            ):
+                candidates = agent_server.local_codex_session_candidates(set())
+
+        self.assertEqual(len(candidates), 1)
+        label = candidates[0]["label"]
+        self.assertNotIn("recommended_plugins", label)
+        self.assertIn("octopuses", label)
+
+    def test_reads_a_session_that_was_never_registered_in_the_index(self) -> None:
+        # codex exec (headless) never writes session_index.jsonl; scanning the
+        # transcript directly is the only reliable way to find these sessions.
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions_root = Path(temporary) / "codex-sessions"
+            transcript = sessions_root / "2026" / "08" / "23" / "rollout-01a02d6d.jsonl"
+            write_codex_transcript(
+                transcript,
+                session_id="01a02d6d-76c4-7912-ac70-1ed02a436fe9",
+                cwd="/private/tmp/codex-fun-fact",
+                first_user_text="Tell me one fun fact about narwhals."
+            )
+            missing_index = Path(temporary) / "session_index.jsonl"
+
+            with patch.object(agent_server, "CODEX_SESSIONS_ROOT", sessions_root), patch.object(
+                agent_server, "CODEX_SESSION_INDEX_PATH", missing_index
+            ):
+                candidates = agent_server.local_codex_session_candidates(set())
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate["provider_session_id"], "01a02d6d-76c4-7912-ac70-1ed02a436fe9")
+        self.assertEqual(candidate["backend"], agent_server.BACKEND_CODEX)
+        self.assertEqual(candidate["cwd"], "/private/tmp/codex-fun-fact")
+        self.assertIn("codex-fun-fact", candidate["label"])
+        self.assertIn("narwhals", candidate["label"])
+
+    def test_prefers_the_session_index_thread_name_when_one_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions_root = Path(temporary) / "codex-sessions"
+            transcript = sessions_root / "2026" / "07" / "18" / "rollout-019f76aa.jsonl"
+            write_codex_transcript(
+                transcript,
+                session_id="019f76aa-7880-7023-b350-cb7a24a754d8",
+                cwd="/Volumes/SSD/Codes/ZenithDock",
+                first_user_text="set up remote zenith dock please"
+            )
+            index_path = Path(temporary) / "session_index.jsonl"
+            index_path.write_text(
+                json.dumps({
+                    "id": "019f76aa-7880-7023-b350-cb7a24a754d8",
+                    "thread_name": "Set up remote Zenith Dock",
+                    "updated_at": "2026-07-18T19:19:47.713052Z",
+                }) + "\n"
+            )
+
+            with patch.object(agent_server, "CODEX_SESSIONS_ROOT", sessions_root), patch.object(
+                agent_server, "CODEX_SESSION_INDEX_PATH", index_path
+            ):
+                candidates = agent_server.local_codex_session_candidates(set())
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["label"], "Set up remote Zenith Dock")
+
+    def test_dedups_against_already_imported_provider_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions_root = Path(temporary) / "codex-sessions"
+            transcript = sessions_root / "2026" / "01" / "01" / "rollout-thread-1.jsonl"
+            write_codex_transcript(transcript, session_id="thread-1", cwd="/work", first_user_text="hello")
+            missing_index = Path(temporary) / "session_index.jsonl"
+
+            with patch.object(agent_server, "CODEX_SESSIONS_ROOT", sessions_root), patch.object(
+                agent_server, "CODEX_SESSION_INDEX_PATH", missing_index
+            ):
+                candidates = agent_server.local_codex_session_candidates({"thread-1"})
+
+        self.assertEqual(candidates, [])
+
+    def test_missing_sessions_root_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            missing_root = Path(temporary) / "does-not-exist"
+            missing_index = Path(temporary) / "session_index.jsonl"
+            with patch.object(agent_server, "CODEX_SESSIONS_ROOT", missing_root), patch.object(
+                agent_server, "CODEX_SESSION_INDEX_PATH", missing_index
+            ):
+                candidates = agent_server.local_codex_session_candidates(set())
+        self.assertEqual(candidates, [])
+
+
+class LocalSessionCandidatesDedupAgainstStoreTests(unittest.TestCase):
+    def test_excludes_sessions_already_present_in_store(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            projects_root = Path(temporary) / "claude-projects"
+            transcript = projects_root / "-Users-georgia-code-widget" / "claude-already-imported.jsonl"
+            write_claude_transcript(transcript, cwd="/Users/georgia/code/widget", first_user_text="hello")
+
+            existing_sessions = {
+                "sess_existing": {
+                    "backend": agent_server.BACKEND_CLAUDE,
+                    "claude_session_id": "claude-already-imported",
+                }
+            }
+
+            missing_codex_sessions_root = Path(temporary) / "no-such-codex-sessions"
+            missing_codex_index = Path(temporary) / "no-such-session-index.jsonl"
+            with patch.object(agent_server, "CLAUDE_PROJECTS_ROOT", projects_root), patch.object(
+                agent_server, "CODEX_SESSIONS_ROOT", missing_codex_sessions_root
+            ), patch.object(
+                agent_server, "CODEX_SESSION_INDEX_PATH", missing_codex_index
+            ), patch.object(agent_server.STORE, "sessions", existing_sessions):
+                candidates = agent_server.local_session_candidates(limit=200)
+
+        self.assertEqual(candidates, [])
+
+
+class BulkImportSessionsEndpointTests(unittest.IsolatedAsyncioTestCase):
+    async def test_rejects_empty_items(self) -> None:
+        with self.assertRaises(agent_server.HTTPException) as raised:
+            await agent_server.bulk_import_sessions(agent_server.BulkImportSessionsRequest(items=[]))
+        self.assertEqual(raised.exception.status_code, 400)
+
+    async def test_rejects_batches_over_the_cap(self) -> None:
+        items = [
+            agent_server.BulkImportSessionItem(provider_session_id=f"id-{i}", backend=agent_server.BACKEND_CLAUDE)
+            for i in range(agent_server.MAX_BULK_IMPORT_ITEMS + 1)
+        ]
+        with self.assertRaises(agent_server.HTTPException) as raised:
+            await agent_server.bulk_import_sessions(agent_server.BulkImportSessionsRequest(items=items))
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertIn(str(agent_server.MAX_BULK_IMPORT_ITEMS), str(raised.exception.detail))
+
+    async def test_records_per_item_failure_without_aborting_the_batch(self) -> None:
+        items = [
+            agent_server.BulkImportSessionItem(provider_session_id="bad-backend", backend="not-a-real-backend"),
+        ]
+        result = await agent_server.bulk_import_sessions(agent_server.BulkImportSessionsRequest(items=items))
+        self.assertEqual(len(result["results"]), 1)
+        self.assertFalse(result["results"][0]["ok"])
+        self.assertEqual(result["results"][0]["provider_session_id"], "bad-backend")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `GET /api/local-sessions`, which scans `~/.claude/projects` and Codex's rollout transcripts under `~/.codex/sessions` for chat history that predates AgentsDock, so it can be offered for bulk import instead of requiring one `provider_session_id` pasted in at a time.
- Adds `POST /api/sessions/bulk-import`, capped at 25 items per request, reusing the existing single-session create+import path in a loop.
- Fixes Codex session discovery to scan transcripts directly rather than relying on `session_index.jsonl`, which turns out not to be written by `codex exec` and, in testing, not reliably by interactive sessions either — the old approach was missing the large majority of real local Codex sessions.
- Filters Codex's injected `<recommended_plugins>` turn out of imported history and generated labels (it was leaking into both).

## Test plan
- [x] `python -m unittest test_local_sessions_import` (13 new tests)
- [x] `python -m unittest test_local_sessions_import test_session_forking test_codex_resume_recovery test_handoff_digest` — no regressions
- [x] Verified end-to-end against real local Claude/Codex history on a live instance: discovery returns real sessions with sensible labels/cwd, bulk-import creates real resumable sessions, imported sessions correctly drop out of the candidate list on the next call

Pairs with the ZenithDock PR that adds the "Import Chat" entry in the composer's new Skills section and its dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)