### PR TITLE
Keep Codex goal continuations owned

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -25753,6 +25753,11 @@ async def run_codex_app_server(
     error_emitted = False
     delivery_unknown = False
     turn_completed = False
+    goal = sess.get("codex_goal")
+    native_goal_status = (
+        str(goal.get("status") or "") if isinstance(goal, dict) else ""
+    )
+    awaiting_goal_continuation = False
     current_run_id = run_id
     current_provider_prompt = prompt
     current_diff_baseline = diff_baseline
@@ -26121,6 +26126,11 @@ async def run_codex_app_server(
         if turn is None or turn_completed:
             raise NativeSteerHandoffError(
                 "the active Codex turn has already completed",
+                safe_to_requeue=True,
+            )
+        if awaiting_goal_continuation:
+            raise NativeSteerHandoffError(
+                "the active Codex goal is starting its next turn",
                 safe_to_requeue=True,
             )
 
@@ -26577,6 +26587,7 @@ async def run_codex_app_server(
 
     async def handle_notification(notification: dict[str, Any]) -> bool:
         nonlocal terminal_status, terminal_error, turn_completed
+        nonlocal native_goal_status, awaiting_goal_continuation
         nonlocal pending_unknown_message, pending_unknown_item_id
         nonlocal ambiguous_turn_start, error_emitted
         method = str(notification.get("method") or "")
@@ -26591,6 +26602,30 @@ async def run_codex_app_server(
         if turn is not None and turn.turn_id:
             ambiguous_turn_start = False
             await bind_active_turn_and_reconcile_stop()
+
+        if method == "turn/started" and awaiting_goal_continuation:
+            awaiting_goal_continuation = False
+            terminal_status = "failed"
+            terminal_error = None
+
+        if method == "thread/goal/updated":
+            updated_goal = params.get("goal")
+            native_goal_status = (
+                str(updated_goal.get("status") or "")
+                if isinstance(updated_goal, dict)
+                else ""
+            )
+            if awaiting_goal_continuation and native_goal_status != "active":
+                turn_completed = True
+                return True
+            return False
+
+        if method == "thread/goal/cleared":
+            native_goal_status = ""
+            if awaiting_goal_continuation:
+                turn_completed = True
+                return True
+            return False
 
         stopped_output = stop_requested_for_current_run()
         if stopped_output:
@@ -26720,6 +26755,13 @@ async def run_codex_app_server(
             terminal_status = str(completed_turn.get("status") or "failed")
             if completed_turn.get("error"):
                 terminal_error = concise_error_message(completed_turn.get("error"))
+            if (
+                terminal_status == "completed"
+                and native_goal_status == "active"
+                and not stop_requested_for_current_run()
+            ):
+                awaiting_goal_continuation = True
+                return False
             turn_completed = True
             return True
         return False
@@ -26977,6 +27019,7 @@ async def run_codex_app_server(
                         provider_id,
                         [{"type": "text", "text": prompt, "text_elements": []}],
                         overrides=overrides,
+                        follow_goal_continuations=True,
                     )
                 except CodexAppServerError as exc:
                     pending_turn = getattr(exc, "pending_turn", None)

--- a/codex_app_server.py
+++ b/codex_app_server.py
@@ -332,6 +332,7 @@ class CodexAppServerTurn:
     thread_id: str
     turn_id: str
     _subscription: CodexAppServerSubscription
+    _follow_goal_continuations: bool = False
     _closed: bool = False
     _completed: bool = False
 
@@ -384,7 +385,8 @@ class CodexAppServerTurn:
                 f"provisional turn already bound to {self.turn_id}, not {resolved}"
             )
         self.turn_id = resolved
-        self._subscription.turn_id = resolved
+        if not self._follow_goal_continuations:
+            self._subscription.turn_id = resolved
 
     async def close(self) -> None:
         if self._closed:
@@ -979,7 +981,10 @@ class CodexAppServerClient:
             # turn/interrupt to target the work that is actually running.
             if not active_turn.turn_id or method == "turn/started":
                 active_turn.turn_id = turn_id
-                active_turn._subscription.turn_id = turn_id
+                if not active_turn._follow_goal_continuations:
+                    active_turn._subscription.turn_id = turn_id
+                if method == "turn/started":
+                    active_turn._completed = False
 
         for subscription in tuple(self._subscriptions):
             if subscription._matches(notification):
@@ -1024,9 +1029,10 @@ class CodexAppServerClient:
         if method == "turn/completed" and active_turn:
             if not turn_id or not active_turn.turn_id or turn_id == active_turn.turn_id:
                 active_turn._completed = True
-                if self._turns_by_thread.get(thread_id) is active_turn:
-                    self._turns_by_thread.pop(thread_id, None)
-                active_turn._subscription._finish()
+                if not active_turn._follow_goal_continuations:
+                    if self._turns_by_thread.get(thread_id) is active_turn:
+                        self._turns_by_thread.pop(thread_id, None)
+                    active_turn._subscription._finish()
         if method == "turn/completed" and thread_id and turn_id:
             self._finish_scoped_subscriptions(thread_id, turn_id=turn_id)
         elif method == "thread/closed" and thread_id:
@@ -2008,6 +2014,7 @@ class CodexAppServerClient:
         input_items: list[dict[str, Any]],
         *,
         overrides: dict[str, Any] | None = None,
+        follow_goal_continuations: bool = False,
     ) -> CodexAppServerTurn:
         # Initialize before installing the provisional turn subscription.
         # Otherwise the first lazy start would correctly discard it as stale
@@ -2019,7 +2026,13 @@ class CodexAppServerClient:
             )
 
         subscription = self.subscribe(thread_id=thread_id)
-        provisional = CodexAppServerTurn(self, thread_id, "", subscription)
+        provisional = CodexAppServerTurn(
+            self,
+            thread_id,
+            "",
+            subscription,
+            _follow_goal_continuations=follow_goal_continuations,
+        )
         self._turns_by_thread[thread_id] = provisional
 
         params = dict(overrides or {})
@@ -2042,7 +2055,8 @@ class CodexAppServerClient:
                     safe_to_retry=False,
                 )
             provisional.turn_id = turn_id
-            provisional._subscription.turn_id = turn_id
+            if not follow_goal_continuations:
+                provisional._subscription.turn_id = turn_id
             return provisional
         except CodexAppServerError as exc:
             if not exc.safe_to_retry:
@@ -2343,11 +2357,13 @@ class CodexAppServerManager:
         input_items: list[dict[str, Any]],
         *,
         overrides: dict[str, Any] | None = None,
+        follow_goal_continuations: bool = False,
     ) -> CodexAppServerTurn:
         return await self.client.start_turn(
             thread_id,
             input_items,
             overrides=overrides,
+            follow_goal_continuations=follow_goal_continuations,
         )
 
     async def steer_turn(

--- a/test_codex_app_server.py
+++ b/test_codex_app_server.py
@@ -1423,6 +1423,52 @@ class CodexAppServerClientTests(unittest.IsolatedAsyncioTestCase):
 
         await turn.close()
 
+    async def test_goal_continuation_can_follow_completed_turn(self) -> None:
+        factory = FakeProcessFactory()
+        process = factory.process
+        process.responders["turn/start"] = lambda _: {
+            "turn": {
+                "id": "turn_initial",
+                "status": "inProgress",
+                "items": [],
+            }
+        }
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+
+        turn = await client.start_turn(
+            "thread_goal",
+            [{"type": "text", "text": "Start goal"}],
+            follow_goal_continuations=True,
+        )
+        completed = {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread_goal",
+                "turn": {"id": "turn_initial", "status": "completed"},
+            },
+        }
+        process.feed(completed)
+        self.assertEqual(await turn.next_notification(timeout=1), completed)
+        self.assertIs(client.active_turn("thread_goal"), turn)
+
+        continued = {
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread_goal",
+                "turn": {
+                    "id": "turn_continued",
+                    "status": "inProgress",
+                    "items": [],
+                },
+            },
+        }
+        process.feed(continued)
+        self.assertEqual(await turn.next_notification(timeout=1), continued)
+        self.assertEqual(turn.turn_id, "turn_continued")
+
+        await turn.close()
+
     async def test_resume_accepts_a_jsonl_response_larger_than_16_mib(self) -> None:
         factory = FakeProcessFactory()
         process = factory.process

--- a/test_codex_app_server_runner.py
+++ b/test_codex_app_server_runner.py
@@ -147,6 +147,7 @@ class FakeManager:
         self.start_calls = 0
         self.read_thread_calls: list[tuple[str, bool]] = []
         self.list_turns_calls: list[tuple[str, int, str, str]] = []
+        self.follow_goal_continuation_calls: list[bool] = []
         self.turn_calls: list[
             tuple[str, list[dict[str, object]], dict[str, object]]
         ] = []
@@ -168,7 +169,9 @@ class FakeManager:
         input_items: list[dict[str, object]],
         *,
         overrides: dict[str, object] | None = None,
+        follow_goal_continuations: bool = False,
     ) -> FakeTurn:
+        self.follow_goal_continuation_calls.append(follow_goal_continuations)
         self.turn_calls.append((thread_id, input_items, dict(overrides or {})))
         if self.start_turn_error is not None:
             raise self.start_turn_error
@@ -613,6 +616,109 @@ class CodexAppServerRunnerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             manager.notification_barriers,
             [(agent_server.project_codex_notification, "thread-native")],
+        )
+
+    async def test_active_goal_keeps_run_owner_across_native_continuation(self) -> None:
+        turn = FakeTurn()
+        manager = FakeManager(turn)
+        self.session["codex_goal"] = {
+            "threadId": "thread-native",
+            "objective": "Finish the task",
+            "status": "active",
+        }
+        stack, events, finished, _exec_fallback = self.runner_patches(manager)
+        with stack:
+            runner = asyncio.create_task(
+                agent_server.run_codex_app_server(
+                    "chat-native",
+                    "run-original",
+                    "Start the goal",
+                    dict(self.session),
+                    Path(self.cwd) / ".runner-test-manifest.json",
+                    allow_exec_fallback=True,
+                    allow_resume_rollover=False,
+                )
+            )
+            for _ in range(100):
+                if (
+                    agent_server.ACTIVE.get("chat-native") or {}
+                ).get("provider_turn_ready"):
+                    break
+                await asyncio.sleep(0)
+            else:
+                self.fail("Codex app-server turn never became ready")
+
+            turn.feed(completed_notification())
+            with self.assertRaises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(runner), timeout=0.01)
+            finished.assert_not_awaited()
+            self.assertTrue(
+                await agent_server.codex_thread_has_local_run_owner(
+                    "chat-native",
+                    "thread-native",
+                )
+            )
+
+            turn.turn_id = "turn-continued"
+            turn.feed({
+                "method": "turn/started",
+                "params": {
+                    "threadId": "thread-native",
+                    "turn": {
+                        "id": "turn-continued",
+                        "status": "inProgress",
+                        "items": [],
+                    },
+                },
+            })
+            turn.feed({
+                "method": "item/completed",
+                "params": {
+                    "threadId": "thread-native",
+                    "turnId": "turn-continued",
+                    "item": {
+                        "id": "continued-final",
+                        "type": "agentMessage",
+                        "text": "Continued goal output.",
+                        "phase": "final_answer",
+                    },
+                },
+            })
+            turn.feed({
+                "method": "thread/goal/updated",
+                "params": {
+                    "threadId": "thread-native",
+                    "goal": {
+                        "threadId": "thread-native",
+                        "objective": "Finish the task",
+                        "status": "complete",
+                    },
+                },
+            })
+            turn.feed({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-native",
+                    "turnId": "turn-continued",
+                    "turn": {
+                        "id": "turn-continued",
+                        "status": "completed",
+                    },
+                },
+            })
+            await asyncio.wait_for(runner, timeout=1)
+
+        self.assertEqual(manager.turn_calls[0][0], "thread-native")
+        self.assertEqual(manager.follow_goal_continuation_calls, [True])
+        continued_output = [
+            call.args[2]["text"]
+            for call in events.await_args_list
+            if call.args[1] == "assistant_text"
+        ]
+        self.assertEqual(continued_output, ["Continued goal output."])
+        self.assertEqual(
+            finished.await_args.args[1]["provider_turn_id"],
+            "turn-continued",
         )
 
     async def test_scheduled_run_metadata_is_attached_to_live_reasoning_and_tools(
@@ -2395,6 +2501,7 @@ class CodexAppServerRunnerTests(unittest.IsolatedAsyncioTestCase):
                 input_items: list[dict[str, object]],
                 *,
                 overrides: dict[str, object] | None = None,
+                follow_goal_continuations: bool = False,
             ) -> FakeTurn:
                 self.turn_calls.append(
                     (thread_id, input_items, dict(overrides or {}))


### PR DESCRIPTION
## Summary

- keep the app-server turn subscription open across native goal continuation boundaries
- retain BUSY/ACTIVE run ownership while an active goal starts its next provider turn
- retarget interruption and event projection to each continuation turn
- reject Force Send during the short between-turn handoff instead of steering a completed turn

## Root cause

Codex can emit `turn/completed` and then immediately start the next native goal turn on the same thread. AgentsServer closed the scoped subscription and finalized the local run at the first completion, so the continuation kept running in Codex without BUSY/ACTIVE ownership and the UI reported the session as idle.

## Validation

- regression tests for `turn/completed` followed by `turn/started`
- regression test that local run ownership and continued output survive the boundary
- `uv lock --check`
- Python 3.13 compile checks
- Python 3.13 full suite: 825 tests passed