### PR TITLE
Render completed commentary in the chat body

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -15266,6 +15266,15 @@ async def send_event_catchup(
     return through if completed_scan else cursor
 
 
+def is_completed_commentary_event(event: dict[str, Any]) -> bool:
+    """Return whether an event is durable completed agent commentary."""
+    return (
+        str(event.get("type") or "") == "reasoning_summary"
+        and str(event.get("phase") or "") == "commentary"
+        and bool(str(event.get("text") or "").strip())
+    )
+
+
 COMPACT_TIMELINE_HIDDEN_TYPES = {
     "raw_event",
     "reasoning_summary",
@@ -15291,6 +15300,8 @@ def is_visible_timeline_event(
         return False
     event_type = str(event.get("type") or "")
     if compact:
+        if is_completed_commentary_event(event):
+            return True
         return event_type not in COMPACT_TIMELINE_HIDDEN_TYPES
     return event_type != "raw_event"
 
@@ -18389,17 +18400,6 @@ def semantic_timeline_event_is_display(event: dict[str, Any]) -> bool:
     return event_type not in TIMELINE_INDEX_TRACE_TYPES and event_type != "turn_started"
 
 
-def semantic_timeline_event_is_completed_commentary(
-    event: dict[str, Any],
-) -> bool:
-    """Return whether an event is durable completed agent commentary."""
-    return (
-        str(event.get("type") or "") == "reasoning_summary"
-        and str(event.get("phase") or "") == "commentary"
-        and bool(str(event.get("text") or "").strip())
-    )
-
-
 def semantic_timeline_event_is_trace_anchor(event: dict[str, Any]) -> bool:
     """Keep one lightweight handle so completed trace detail stays discoverable."""
     event_type = str(event.get("type") or "")
@@ -18467,7 +18467,7 @@ def semantic_timeline_ordinary_candidates(
         event
         for event in remaining
         if preserve_completed_commentary
-        and semantic_timeline_event_is_completed_commentary(event)
+        and is_completed_commentary_event(event)
     ]
     essential = [*detail_essential, *commentary_essential]
     essential_ids = {

--- a/agent_server.py
+++ b/agent_server.py
@@ -14611,8 +14611,27 @@ def event_files_belong_to_session(event: dict[str, Any], session_id: str | None 
     return True
 
 
+def is_completed_commentary_event(event: dict[str, Any]) -> bool:
+    """Return whether an event is durable completed agent commentary."""
+    return (
+        str(event.get("type") or "") in {"reasoning_summary", "assistant_text"}
+        and str(event.get("phase") or "") == "commentary"
+        and bool(str(event.get("text") or "").strip())
+    )
+
+
 def client_safe_event(event: dict[str, Any]) -> dict[str, Any]:
     safe = event
+    if (
+        str(event.get("type") or "") == "reasoning_summary"
+        and is_completed_commentary_event(event)
+    ):
+        # Codex reports completed progress updates as agent messages with the
+        # commentary phase. Keep the provider-shaped event in durable history,
+        # but expose it as assistant text so every client path (live, catch-up,
+        # and reload) renders the update in the conversation body.
+        safe = dict(event)
+        safe["type"] = "assistant_text"
     if (
         "provider_cross_chat_route_snapshot" in event
         or "secure_peer_route_snapshots" in event
@@ -15264,15 +15283,6 @@ async def send_event_catchup(
             completed_scan = True
             break
     return through if completed_scan else cursor
-
-
-def is_completed_commentary_event(event: dict[str, Any]) -> bool:
-    """Return whether an event is durable completed agent commentary."""
-    return (
-        str(event.get("type") or "") == "reasoning_summary"
-        and str(event.get("phase") or "") == "commentary"
-        and bool(str(event.get("text") or "").strip())
-    )
 
 
 COMPACT_TIMELINE_HIDDEN_TYPES = {
@@ -18144,6 +18154,7 @@ def new_semantic_job_state(landmark: dict[str, Any]) -> dict[str, Any]:
         # but these anchors make an interrupted job's retained reasoning
         # visibly discoverable immediately after a chat reload.
         "latest_run_reasoning": None,
+        "latest_run_commentary": None,
         "latest_run_tool": None,
         "title": str(landmark.get("title") or "Scheduled job"),
         "job": None,
@@ -18207,11 +18218,14 @@ def add_semantic_job_event(state: dict[str, Any], event: dict[str, Any]) -> None
             state["latest_run_id"] = run_id
             state["latest_run_extras"] = deque(maxlen=SEMANTIC_TIMELINE_JOB_EXTRA_LIMIT)
             state["latest_run_reasoning"] = None
+            state["latest_run_commentary"] = None
             state["latest_run_tool"] = None
         state["latest_run_seq"] = seq
     if run_id == state.get("latest_run_id"):
         event_type = str(event.get("type") or "")
-        if event_type == "reasoning_summary":
+        if is_completed_commentary_event(event):
+            state["latest_run_commentary"] = event
+        elif event_type == "reasoning_summary":
             state["latest_run_reasoning"] = event
         elif event_type in {"tool_started", "tool_finished"}:
             state["latest_run_tool"] = event
@@ -18429,9 +18443,19 @@ def semantic_timeline_ordinary_candidates(
         (event for event in ordered if str(event.get("type") or "") == "turn_started"),
         None,
     )
+    display_events = [
+        event for event in ordered if semantic_timeline_event_is_display(event)
+    ]
+    # A stopped/completed lifecycle marker remains the turn representative
+    # even when Codex flushes completed commentary afterward. Commentary is
+    # retained separately below, so it must not displace the terminal state.
     latest_display = next(
-        (event for event in reversed(ordered) if semantic_timeline_event_is_display(event)),
-        ordered[-1],
+        (
+            event
+            for event in reversed(display_events)
+            if not is_completed_commentary_event(event)
+        ),
+        display_events[-1] if display_events else ordered[-1],
     )
     primary = [latest_display]
     secondary_event = first_turn
@@ -18695,6 +18719,12 @@ def collect_semantic_timeline_events(
                     [state["latest_run_reasoning"]]
                     if retain_interrupted_trace_anchor
                     and isinstance(state.get("latest_run_reasoning"), dict)
+                    else []
+                ),
+                *(
+                    [state["latest_run_commentary"]]
+                    if retain_interrupted_trace_anchor
+                    and isinstance(state.get("latest_run_commentary"), dict)
                     else []
                 ),
                 *(

--- a/test_compact_timeline_paging.py
+++ b/test_compact_timeline_paging.py
@@ -76,6 +76,31 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
                 else:
                     self.assertEqual(job["prompt"], prompt)
 
+    def test_client_safe_event_projects_completed_commentary_into_chat_body(self) -> None:
+        commentary = self.event(
+            23,
+            "reasoning_summary",
+            run_id="run-1",
+            item_id="commentary-1",
+            phase="commentary",
+            text="Training is healthy at step 25.",
+        )
+        private_reasoning = self.event(
+            24,
+            "reasoning_summary",
+            run_id="run-1",
+            text="Private reasoning",
+        )
+
+        projected = agent_server.client_safe_event(commentary)
+
+        self.assertIsNot(projected, commentary)
+        self.assertEqual(projected["type"], "assistant_text")
+        self.assertEqual(projected["phase"], "commentary")
+        self.assertEqual(projected["text"], commentary["text"])
+        self.assertEqual(commentary["type"], "reasoning_summary")
+        self.assertIs(agent_server.client_safe_event(private_reasoning), private_reasoning)
+
     def test_history_projects_promptless_job_for_older_clients(self) -> None:
         path = agent_server.events_path(self.session_id)
         stored = self.event(1, "job_created", job={"id": "job-1", "title": "Data Repeater"})
@@ -103,6 +128,34 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("prompt", event["job"])
         persisted = json.loads(agent_server.events_path(self.session_id).read_text(encoding="utf-8").splitlines()[-1])
         self.assertNotIn("prompt", persisted["job"])
+
+    async def test_append_event_broadcasts_commentary_as_body_without_rewriting_history(self) -> None:
+        broadcast = AsyncMock()
+        with patch.object(agent_server.HUB, "broadcast", new=broadcast), patch.object(
+            agent_server,
+            "ensure_dirs",
+        ):
+            event = await agent_server.append_event(
+                self.session_id,
+                "reasoning_summary",
+                {
+                    "run_id": "run-1",
+                    "item_id": "commentary-1",
+                    "phase": "commentary",
+                    "text": "Training is healthy at step 25.",
+                },
+            )
+
+        live_event = broadcast.await_args.args[1]
+        self.assertEqual(live_event["type"], "assistant_text")
+        self.assertEqual(live_event["phase"], "commentary")
+        self.assertEqual(event["type"], "reasoning_summary")
+        persisted = json.loads(
+            agent_server.events_path(self.session_id)
+            .read_text(encoding="utf-8")
+            .splitlines()[-1]
+        )
+        self.assertEqual(persisted["type"], "reasoning_summary")
 
     def test_compact_filter_preserves_conversation_system_job_and_file_events(self) -> None:
         default_page = agent_server.read_visible_events_page(
@@ -170,7 +223,7 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
             [(event["seq"], event["type"]) for event in page[0]],
             [
                 (1, "turn_started"),
-                (3, "reasoning_summary"),
+                (3, "assistant_text"),
                 (5, "assistant_text"),
             ],
         )
@@ -658,7 +711,8 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
             for event in page["events"]
         ))
         self.assertTrue(any(
-            event["type"] == "reasoning_summary"
+            event["type"] == "assistant_text"
+            and event.get("phase") == "commentary"
             and event.get("run_id") == "job-run"
             for event in page["events"]
         ))
@@ -669,7 +723,7 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             [event["type"] for event in trace["events"]],
-            ["reasoning_summary", "tool_started"],
+            ["assistant_text", "tool_started"],
         )
 
     def test_native_steer_stop_uses_legacy_run_to_job_mapping(self) -> None:
@@ -1710,7 +1764,7 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
         commentary = [
             event
             for event in page["events"]
-            if event["type"] == "reasoning_summary"
+            if event["type"] == "assistant_text"
             and event.get("phase") == "commentary"
         ]
         self.assertEqual(
@@ -1800,7 +1854,7 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
         commentary = [
             event
             for event in page["events"]
-            if event["type"] == "reasoning_summary"
+            if event["type"] == "assistant_text"
             and event.get("phase") == "commentary"
         ]
         self.assertEqual(
@@ -1891,7 +1945,7 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
         commentary = [
             event
             for event in page["events"]
-            if event["type"] == "reasoning_summary"
+            if event["type"] == "assistant_text"
             and event.get("phase") == "commentary"
         ]
         self.assertEqual(

--- a/test_compact_timeline_paging.py
+++ b/test_compact_timeline_paging.py
@@ -139,6 +139,44 @@ class CompactTimelinePagingTests(unittest.IsolatedAsyncioTestCase):
         ])
         self.assertEqual(compact_page[1:], (22, 11, 0, 0))
 
+    def test_compact_filter_preserves_commentary_but_hides_private_trace(self) -> None:
+        self.write_events([
+            self.event(1, "turn_started", run_id="run-1", prompt="Monitor it"),
+            self.event(
+                2,
+                "reasoning_summary",
+                run_id="run-1",
+                text="Private reasoning",
+            ),
+            self.event(
+                3,
+                "reasoning_summary",
+                run_id="run-1",
+                phase="commentary",
+                text="Training is healthy at step 25.",
+            ),
+            self.event(4, "tool_started", run_id="run-1", tool={"name": "exec"}),
+            self.event(5, "assistant_text", run_id="run-1", text="Still running."),
+        ])
+
+        page = agent_server.read_visible_events_page(
+            self.session_id,
+            limit=100,
+            tail=False,
+            compact=True,
+        )
+
+        self.assertEqual(
+            [(event["seq"], event["type"]) for event in page[0]],
+            [
+                (1, "turn_started"),
+                (3, "reasoning_summary"),
+                (5, "assistant_text"),
+            ],
+        )
+        self.assertEqual(page[0][1]["phase"], "commentary")
+        self.assertEqual(page[1:], (5, 3, 0, 0))
+
     def test_compact_before_and_after_pages_count_only_compact_events(self) -> None:
         before_page = agent_server.read_visible_events_page(
             self.session_id,

--- a/test_event_websocket_catchup.py
+++ b/test_event_websocket_catchup.py
@@ -24,6 +24,40 @@ class FakeWebSocket:
 
 
 class EventWebSocketCatchupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_catchup_projects_completed_commentary_into_chat_body(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "events.jsonl"
+            path.write_text(
+                json.dumps({
+                    "seq": 1,
+                    "id": "commentary-1",
+                    "session_id": "chat",
+                    "type": "reasoning_summary",
+                    "phase": "commentary",
+                    "ts": "2026-07-28T00:00:00Z",
+                    "text": "Still validating step 25.",
+                })
+                + "\n",
+                encoding="utf-8",
+            )
+
+            socket = FakeWebSocket()
+            with (
+                patch.object(agent_server, "events_path", return_value=path),
+                patch.object(agent_server, "fork_internal_run_ids", return_value=set()),
+            ):
+                cursor = await agent_server.send_event_catchup(
+                    "chat",
+                    socket,  # type: ignore[arg-type]
+                    after=0,
+                    through=1,
+                    visible=True,
+                )
+
+        self.assertEqual(cursor, 1)
+        self.assertEqual(socket.events[0]["type"], "assistant_text")
+        self.assertEqual(socket.events[0]["phase"], "commentary")
+
     async def test_catchup_drains_more_than_one_page_without_raw_events(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             path = Path(root) / "events.jsonl"


### PR DESCRIPTION
## Summary

- preserve completed `phase=commentary` events across compact and semantic timeline refreshes
- project completed commentary to `assistant_text` only at the client boundary, so live WebSocket delivery, catch-up, and reload render it in the chat body
- keep durable provider history as `reasoning_summary` and leave ordinary private reasoning/tool traces folded
- retain stop markers and interrupted scheduled-job commentary during semantic paging

## Regression coverage

- verifies live broadcasts expose commentary as body text without rewriting persisted JSONL
- verifies WebSocket catch-up and compact history use the same body projection
- verifies private reasoning remains trace-only
- verifies active, steered, stopped, and scheduled runs retain completed commentary

## Tests

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m unittest test_compact_timeline_paging test_event_websocket_catchup` (48 passed)
- targeted Codex/timeline/fork/handoff suites (256 passed)
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m unittest discover` (1355 passed)