### PR TITLE
Codex app-server: fail fast and recover when an accepted turn goes silent (#37)

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -463,6 +463,18 @@ HOST_MONITOR_INTERVAL_SECONDS = float(agentsdock_setting("HOST_MONITOR_INTERVAL_
 HOST_HEALTH_MAX_BYTES = int(agentsdock_setting("HOST_HEALTH_MAX_BYTES", str(20 * 1024 * 1024)))
 IDLE_WARN_SECONDS = int(agentsdock_setting("IDLE_WARN_SECONDS", "1800"))
 IDLE_KILL_SECONDS = int(agentsdock_setting("IDLE_KILL_SECONDS", "21600"))
+# A Codex app-server notification can be silently dropped if it arrives for a
+# subscription that already closed (see _route_notification in
+# codex_app_server.py) - the turn then waits forever with zero visible
+# activity, but IDLE_WARN/IDLE_KILL_SECONDS above are sized for legitimate
+# gaps *between* activity on an already-productive turn, not "nothing has
+# happened since the turn started." This bounds only that first-activity
+# wait, far tighter, so a stalled turn fails fast and (if resuming an
+# existing thread) is picked up by the existing rollover-retry path instead
+# of hanging with no error for up to IDLE_KILL_SECONDS.
+CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS = int(
+    agentsdock_setting("CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS", "180")
+)
 CURSOR_STARTUP_TIMEOUT_SECONDS = max(
     5.0,
     float(agentsdock_setting("CURSOR_STARTUP_TIMEOUT_SECONDS", "120")),
@@ -44586,6 +44598,11 @@ async def run_codex_app_server(
     terminal_status = "failed"
     terminal_error: str | None = None
     error_emitted = False
+    # Set when the turn was accepted but produced no notification at all
+    # within CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS. Treated as a
+    # stalled resume below so a resumed thread gets the same one-shot
+    # rollover-onto-a-fresh-thread recovery the exec transport already has.
+    first_activity_stalled = False
     delivery_unknown = False
     turn_completed = False
     current_run_id = run_id
@@ -45979,6 +45996,7 @@ async def run_codex_app_server(
                     )
                 )
                 last_activity = time.monotonic()
+                first_activity_seen = False
                 notification_task = asyncio.create_task(
                     next_sequenced_notification()
                 )
@@ -46009,6 +46027,40 @@ async def run_codex_app_server(
                         )
                         if not done:
                             idle = time.monotonic() - last_activity
+                            if (
+                                not first_activity_seen
+                                and idle >= CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS
+                            ):
+                                # turn/start was accepted but nothing at all
+                                # has come back since - most likely a
+                                # notification for this turn was dropped by
+                                # _route_notification finding no matching
+                                # subscription (see its docstring). Fail fast
+                                # instead of waiting out the much longer
+                                # IDLE_KILL_SECONDS meant for gaps *between*
+                                # activity on an already-productive turn.
+                                terminal_error = (
+                                    "Codex app-server produced no activity within "
+                                    f"{CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS}s "
+                                    "of accepting this turn."
+                                )
+                                first_activity_stalled = True
+                                dropped = [
+                                    entry for entry in manager.client.unmatched_notifications
+                                    if entry.get("thread_id") == provider_id
+                                ]
+                                logger.warning(
+                                    "codex app-server first-activity timeout session=%s run=%s thread=%s dropped_notifications=%s",
+                                    session_id,
+                                    current_run_id,
+                                    provider_id,
+                                    dropped,
+                                )
+                                if turn.turn_id:
+                                    with suppress(CodexAppServerError):
+                                        await turn.interrupt()
+                                terminal_status = "failed"
+                                break
                             if idle >= IDLE_WARN_SECONDS:
                                 await append_event(session_id, "idle_warning", {
                                     "run_id": current_run_id,
@@ -46032,6 +46084,7 @@ async def run_codex_app_server(
                                 sequence,
                             )
                             last_activity = time.monotonic()
+                            first_activity_seen = True
                             async with logical_state_lock:
                                 completed = await handle_notification(notification)
                             if completed:
@@ -46236,7 +46289,7 @@ async def run_codex_app_server(
             stopped=stopped,
             stream_error=None,
             idle_killed=False,
-            resume_stalled=False,
+            resume_stalled=first_activity_stalled,
             returncode=0 if terminal_status == "completed" else 1,
             produced_activity=produced_activity,
             terminal_error=terminal_error or "",

--- a/codex_app_server.py
+++ b/codex_app_server.py
@@ -515,6 +515,11 @@ class CodexAppServerClient:
         ] = {}
         self._server_request_tasks: dict[Any, asyncio.Task[None]] = {}
         self._stderr_tail: deque[str] = deque(maxlen=40)
+        # Diagnostic-only record of notifications _route_notification could
+        # not match to any live subscription (see its docstring) - these are
+        # otherwise dropped with no trace, which is exactly what makes a
+        # stalled turn look like it hung for no reason.
+        self._unmatched_notifications: deque[dict[str, Any]] = deque(maxlen=40)
         self._closing = False
         self._initialized = False
         self._initialize_result: dict[str, Any] | None = None
@@ -533,6 +538,10 @@ class CodexAppServerClient:
     @property
     def stderr_tail(self) -> list[str]:
         return list(self._stderr_tail)
+
+    @property
+    def unmatched_notifications(self) -> list[dict[str, Any]]:
+        return list(self._unmatched_notifications)
 
     @property
     def process(self) -> asyncio.subprocess.Process | None:
@@ -1032,9 +1041,18 @@ class CodexAppServerClient:
                 active_turn.turn_id = turn_id
                 active_turn._subscription.turn_id = turn_id
 
+        matched = False
         for subscription in tuple(self._subscriptions):
             if subscription._matches(notification):
                 subscription._put(notification)
+                matched = True
+        if not matched:
+            self._unmatched_notifications.append({
+                "method": method,
+                "thread_id": thread_id,
+                "turn_id": turn_id,
+                "at": time.time(),
+            })
 
         for handler in tuple(self._notification_handlers):
             owner = (handler, thread_id or "")

--- a/test_codex_app_server.py
+++ b/test_codex_app_server.py
@@ -214,6 +214,57 @@ class CodexAppServerClientTests(unittest.IsolatedAsyncioTestCase):
         })
         self.assertEqual(seen, ["item/started"])
 
+    async def test_unmatched_notification_is_recorded_not_silently_dropped(self) -> None:
+        # No subscription exists for "thread-nobody-listens" - previously
+        # this notification just vanished with zero trace, which is what
+        # made a stalled turn look like it hung for no reason.
+        client = self.make_client(FakeProcessFactory())
+        self.addAsyncCleanup(client.close)
+
+        client._route_notification({
+            "method": "item/completed",
+            "params": {"threadId": "thread-nobody-listens", "turnId": "turn-1"},
+        })
+
+        recorded = client.unmatched_notifications
+        self.assertEqual(len(recorded), 1)
+        self.assertEqual(recorded[0]["method"], "item/completed")
+        self.assertEqual(recorded[0]["thread_id"], "thread-nobody-listens")
+        self.assertEqual(recorded[0]["turn_id"], "turn-1")
+
+    async def test_matched_notification_is_not_recorded_as_unmatched(self) -> None:
+        client = self.make_client(FakeProcessFactory())
+        self.addAsyncCleanup(client.close)
+        subscription = client.subscribe_thread("thread-a")
+        self.addCleanup(subscription.close)
+
+        client._route_notification({
+            "method": "item/completed",
+            "params": {"threadId": "thread-a"},
+        })
+
+        self.assertEqual(client.unmatched_notifications, [])
+        _sequence, delivered = await asyncio.wait_for(
+            subscription.next_notification_with_sequence(), timeout=1
+        )
+        self.assertEqual(delivered["method"], "item/completed")
+
+    async def test_unmatched_notification_backlog_is_bounded(self) -> None:
+        client = self.make_client(FakeProcessFactory())
+        self.addAsyncCleanup(client.close)
+
+        for i in range(45):
+            client._route_notification({
+                "method": "item/completed",
+                "params": {"threadId": f"thread-{i}"},
+            })
+
+        recorded = client.unmatched_notifications
+        self.assertEqual(len(recorded), 40)
+        # Only the most recent 40 survive - the oldest 5 were evicted.
+        self.assertEqual(recorded[0]["thread_id"], "thread-5")
+        self.assertEqual(recorded[-1]["thread_id"], "thread-44")
+
     async def test_initialize_once_and_reuse_one_process(self) -> None:
         factory = FakeProcessFactory()
         process = factory.process

--- a/test_codex_app_server_runner.py
+++ b/test_codex_app_server_runner.py
@@ -136,6 +136,14 @@ class GatedSteerTurn(FakeTurn):
         self.steer_acknowledged.set()
 
 
+class FakeAppServerClient:
+    """Mirrors the one real attribute run_codex_app_server reads off
+    manager.client: the diagnostic unmatched-notification backlog."""
+
+    def __init__(self) -> None:
+        self.unmatched_notifications: list[dict[str, object]] = []
+
+
 class FakeManager:
     def __init__(
         self,
@@ -146,6 +154,7 @@ class FakeManager:
         read_thread_result: dict[str, object] | None = None,
     ) -> None:
         self.turn = turn or FakeTurn()
+        self.client = FakeAppServerClient()
         self.turns = list(turns or [])
         self.start_turn_error = start_turn_error
         self.read_thread_result = read_thread_result
@@ -3139,6 +3148,174 @@ class CodexAppServerRunnerTests(unittest.IsolatedAsyncioTestCase):
         ]
         self.assertEqual(len(finals), 1)
         self.assertEqual(finals[0]["run_id"], run_now["run_id"])
+
+    async def test_first_activity_timeout_fails_fast_instead_of_hanging(self) -> None:
+        # turn/start is accepted (FakeManager.start_turn returns a FakeTurn),
+        # but nothing is ever fed into it - simulating a notification that
+        # _route_notification could not match to any subscription and
+        # silently dropped (GitHub issue #37). Without this timeout, the
+        # turn would only fail after the much longer IDLE_KILL_SECONDS.
+        turn = FakeTurn()
+        manager = FakeManager(turn)
+        real_wait = asyncio.wait
+
+        async def fast_poll(
+            futures: set[asyncio.Future[object] | asyncio.Task[object]],
+            *,
+            timeout: float | None = None,
+            return_when: str = asyncio.ALL_COMPLETED,
+        ) -> tuple[
+            set[asyncio.Future[object] | asyncio.Task[object]],
+            set[asyncio.Future[object] | asyncio.Task[object]],
+        ]:
+            return await real_wait(
+                futures,
+                timeout=min(0.01, timeout) if timeout is not None else 0.01,
+                return_when=return_when,
+            )
+
+        manager.client.unmatched_notifications.append({
+            "method": "item/completed",
+            "thread_id": "thread-native",
+            "turn_id": "turn-native",
+            "at": time.time(),
+        })
+
+        stack, events, finished, _exec_fallback = self.runner_patches(manager)
+        with stack, patch.object(
+            agent_server.asyncio,
+            "wait",
+            fast_poll,
+        ), patch.object(
+            agent_server,
+            "CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS",
+            0.05,
+        ), patch.object(
+            agent_server,
+            "IDLE_WARN_SECONDS",
+            1800,
+        ), patch.object(
+            agent_server,
+            "IDLE_KILL_SECONDS",
+            21600,
+        ):
+            await asyncio.wait_for(
+                agent_server.run_codex_app_server(
+                    "chat-native",
+                    "run-original",
+                    "Original request",
+                    dict(self.session),
+                    Path(self.cwd) / ".runner-test-manifest.json",
+                    allow_exec_fallback=True,
+                    allow_resume_rollover=False,
+                ),
+                timeout=2,
+            )
+
+        self.assertEqual(turn.interrupt_calls, 1)
+        error_calls = [
+            call for call in events.await_args_list
+            if call.args[1] == "error"
+        ]
+        self.assertTrue(error_calls)
+        self.assertIn(
+            "no activity",
+            str(error_calls[-1].args[2].get("message") or ""),
+        )
+        self.assertTrue(finished.await_args)
+
+    async def test_first_activity_timeout_rolls_a_resumed_thread_over_and_retries(
+        self,
+    ) -> None:
+        # The user-visible half of the fix: a resumed thread that goes
+        # completely silent must not just fail - it gets the same one-shot
+        # rollover-onto-a-fresh-thread retry the exec transport already has,
+        # so the chat recovers on its own instead of stopping at an error.
+        silent_turn = FakeTurn()
+        recovered_turn = FakeTurn([
+            agent_message(
+                "msg-after-stall",
+                "Recovered on a fresh thread.",
+                "final_answer",
+            ),
+            completed_notification(),
+        ])
+        manager = FakeManager(turns=[silent_turn, recovered_turn])
+        real_wait = asyncio.wait
+
+        async def fast_poll(
+            futures: set[asyncio.Future[object] | asyncio.Task[object]],
+            *,
+            timeout: float | None = None,
+            return_when: str = asyncio.ALL_COMPLETED,
+        ) -> tuple[
+            set[asyncio.Future[object] | asyncio.Task[object]],
+            set[asyncio.Future[object] | asyncio.Task[object]],
+        ]:
+            return await real_wait(
+                futures,
+                timeout=min(0.01, timeout) if timeout is not None else 0.01,
+                return_when=return_when,
+            )
+
+        fresh_session = {
+            "id": "chat-native",
+            "backend": agent_server.BACKEND_CODEX,
+            "cwd": self.cwd,
+            "memory_seed": "bounded context",
+            "memory_seed_used": False,
+        }
+        rollover = AsyncMock(return_value=(fresh_session, "bounded context"))
+        ensure = AsyncMock(
+            side_effect=[
+                ("thread-native", "old-policy"),
+                ("thread-fresh", "fresh-policy"),
+            ]
+        )
+
+        stack, events, _finished, _exec_fallback = self.runner_patches(manager)
+        with stack, patch.object(
+            agent_server.asyncio,
+            "wait",
+            fast_poll,
+        ), patch.object(
+            agent_server,
+            "CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS",
+            0.05,
+        ), patch.object(
+            agent_server,
+            "ensure_codex_app_server_thread",
+            ensure,
+        ), patch.object(
+            agent_server,
+            "rollover_codex_provider_session",
+            rollover,
+        ):
+            await asyncio.wait_for(
+                agent_server.run_codex_app_server(
+                    "chat-native",
+                    "run-original",
+                    "Original request",
+                    dict(self.session),
+                    Path(self.cwd) / ".runner-test-manifest.json",
+                    allow_exec_fallback=True,
+                    allow_resume_rollover=True,
+                ),
+                timeout=2,
+            )
+
+        rollover.assert_awaited_once()
+        # The stalled thread was interrupted, then the turn was retried.
+        self.assertEqual(silent_turn.interrupt_calls, 1)
+        self.assertEqual(len(manager.turn_calls), 2)
+        # The retry actually produced the reply the first attempt never did.
+        finals = [
+            call.args[2]
+            for call in events.await_args_list
+            if call.args[1] == "assistant_text"
+            and call.args[2].get("item_id") == "msg-after-stall"
+        ]
+        self.assertEqual(len(finals), 1)
 
     async def test_simultaneous_completion_and_steer_settles_force_send(self) -> None:
         turn = FakeTurn([completed_notification()])


### PR DESCRIPTION
Fixes #37.

## The symptom

`turn/start` is accepted (server logs `POST /api/sessions/.../turns -> 200 OK`), but the chat then waits forever with no reply **and no error**, while the identical prompt through the raw terminal path works fine.

## What makes it silent

The shared `codex app-server` process multiplexes every Codex conversation over one pipe. `_route_notification` matches each incoming notification to a live subscription by `(thread_id, turn_id)`. A subscription binds its `turn_id` once `turn/start` returns — so from that point, any notification for that thread carrying a different or absent `turnId` matches nothing, and was then dropped with **no handler, no log, no counter**. Nothing downstream ever learned it existed.

The only backstop was the idle timer borrowed from the `exec` transport, which is sized for gaps *between* activity on an already-productive turn (`IDLE_WARN` 30min / `IDLE_KILL` 6h). A turn that produced nothing at all was therefore indistinguishable from "hung forever" for hours.

Notably, the `exec` transport already received a fix for this same class of silent failure (`869ca59` "Recover silent Codex resumes"). The app-server transport never got the equivalent — this closes that gap.

## Changes

1. **Observability (no behavior change):** `_route_notification` records unmatched notifications in a bounded 40-entry ring instead of discarding them invisibly. This is what will identify the specific dropped notification on the next repro.
2. **Bounded first-activity wait:** if an accepted turn produces no notification at all within `CODEX_APP_SERVER_FIRST_ACTIVITY_TIMEOUT_SECONDS` (default 180s, env-overridable), the turn is interrupted, any unmatched notifications for that thread are logged, and it fails with a clear message. The guard covers **only the first** notification — once a turn is productive the existing idle timers own it, so legitimately long-running turns are unaffected.
3. **Self-recovery:** that stall is reported as a stalled resume, so a resumed thread gets the same one-shot rollover-onto-a-fresh-thread retry the `exec` transport already had. User-visible result: the chat recovers on its own instead of stopping at an error, and can never sit on "Running" with no information again.

## Honest scope note

The silent-drop mechanism is proven by code reading, and is a real robustness gap worth fixing regardless. However, I have **not** proven it is the root cause of the specific report in #37 — the reporter says restarting AgentsServer did not help, and a purely transient routing race would normally clear on restart. That points at something more persistent (thread-specific state) as the underlying trigger.

That is precisely why change #1 exists. This PR guarantees the failure is fast, visible, logged, and self-recovering rather than an indefinite silent hang, and the new diagnostics will name the actual root cause the next time it occurs.

## Test plan

All three new test groups were verified to **fail against the pre-fix code**:

- [x] unmatched notifications are recorded; matched ones are not; the ring is bounded
- [x] an accepted-but-silent turn fails fast and interrupts, instead of waiting out `IDLE_KILL_SECONDS`
- [x] a silent *resumed* thread rolls over, and the retry produces the reply the first attempt never did (reverting only the `resume_stalled` line makes rollover fire 0 times, confirming the retry genuinely comes from this change)
- [x] Full suite: 1630 passed, same pre-existing 47 failures as `origin/main` (installer + team-hub, unrelated and environment-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)