### PR TITLE
Cursor: merge streamed reasoning into one block, and deliver files when shell is blocked

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -812,7 +812,21 @@ You are operating through AgentsDock, backed by AgentsServer.
 SYSTEM_PROMPT = CLAUDE_PROMPT_PRELUDE
 
 CODEX_THREAD_POLICY_VERSION = "7"
-CURSOR_PROMPT_POLICY_VERSION = "1"
+CURSOR_PROMPT_POLICY_VERSION = "2"
+# Cursor sessions run under a per-session permission mode, and every mode
+# except "full_access" rejects shell commands outright. The shared prelude
+# presents the publish CLI as the only sanctioned delivery route and frames
+# the manifest as an "older-server fallback", so a shell-blocked Cursor turn
+# would generate a file, fail to publish it, and tell the user to open it
+# from disk themselves. Writing the manifest needs no shell (verified live:
+# `--trust` alone can write outside the workspace), so make that the
+# explicit route whenever the publish command cannot run.
+CURSOR_FILE_DELIVERY_ADDENDUM = """\
+Delivering files in this Cursor session:
+- Shell commands are rejected in every permission mode except full access. If the AgentsDock publish command comes back rejected, the file is still undelivered - never fall back to telling the user to open it from disk themselves.
+- Deliver it instead by writing `{{"files":["/absolute/path.ext"]}}` to `{manifest_path}` with your file-writing tool, which needs no shell, then say only "submitted for attachment".
+- This covers everything produced for the user, including generated images: write the image to a real file first, then list that absolute path in the manifest.
+"""
 CLAUDE_SDK_CONFIGURATION_VERSION = 7
 CODEX_PROMPT_PRELUDE = """\
 You are operating through AgentsDock, backed by AgentsServer.
@@ -43753,6 +43767,9 @@ def cursor_provider_instructions(
                 terminal_session=terminal_session_name(session_id),
                 chat_id=session_id,
             ).rstrip(),
+            CURSOR_FILE_DELIVERY_ADDENDUM.format(
+                manifest_path=str(manifest_path),
+            ).rstrip(),
             session_prompt_addendum(sess).strip(),
         )
         if value
@@ -44036,7 +44053,32 @@ async def run_cursor(
     changed_paths: set[str] = set()
     seen_artifacts: set[str] = set()
     stderr_bytes = b""
+    # Cursor streams reasoning as many token-sized `thinking` deltas, while
+    # Codex publishes exactly one reasoning_summary per reasoning item and
+    # the client renders one event as one block. Emitting every delta turned
+    # a single thought into a burst of answer-looking blocks that the
+    # timeline then reconciled away. Buffer deltas and publish one event per
+    # completed thought instead.
+    reasoning_buffer: list[str] = []
+    reasoning_buffer_chars = 0
     manifest_watch_task = asyncio.create_task(watch_manifest_artifacts(session_id, run_id, manifest_path, seen_artifacts))
+
+    async def flush_cursor_reasoning() -> None:
+        nonlocal reasoning_buffer, reasoning_buffer_chars
+        if not reasoning_buffer:
+            return
+        text = compact_memory_text(
+            "".join(reasoning_buffer).strip(),
+            CODEX_APP_SERVER_TOOL_OUTPUT_MAX_CHARS,
+        )
+        reasoning_buffer = []
+        reasoning_buffer_chars = 0
+        if text:
+            await append_event(session_id, "reasoning_summary", {
+                "run_id": run_id,
+                "text": text,
+                "phase": "commentary",
+            })
 
     async def emit_provider_session(new_provider_id: str) -> None:
         nonlocal provider_id, provider_started
@@ -44206,6 +44248,10 @@ async def run_cursor(
                 await terminate_process_tree(proc)
                 break
             elif kind == "assistant_text":
+                # Publish the thought that led here before the answer itself,
+                # so the timeline keeps provider order even when Cursor never
+                # sends the matching `thinking/completed`.
+                await flush_cursor_reasoning()
                 text = compact_memory_text(
                     clean_assistant_text(str(normalized.get("text") or "")),
                     CURSOR_TEXT_EVENT_MAX_CHARS,
@@ -44222,13 +44268,14 @@ async def run_cursor(
                         accumulated_text_chars += len(retained_text)
                     await append_event(session_id, "assistant_text", {"run_id": run_id, "text": text, **run_event_metadata(run_id)})
             elif kind == "reasoning_delta":
-                text = compact_memory_text(
-                    str(normalized.get("text") or ""),
-                    CODEX_APP_SERVER_TOOL_OUTPUT_MAX_CHARS,
-                )
-                if text:
-                    await append_event(session_id, "reasoning_summary", {"run_id": run_id, "text": text, "phase": "commentary"})
+                delta = str(normalized.get("text") or "")
+                if delta and reasoning_buffer_chars < CODEX_APP_SERVER_TOOL_OUTPUT_MAX_CHARS:
+                    reasoning_buffer.append(delta)
+                    reasoning_buffer_chars += len(delta)
+            elif kind == "reasoning_completed":
+                await flush_cursor_reasoning()
             elif kind == "tool_started":
+                await flush_cursor_reasoning()
                 call_id = str(normalized["call_id"])
                 if (
                     call_id not in started_tool_ids
@@ -44326,6 +44373,10 @@ async def run_cursor(
             type(e).__name__,
         )
     finally:
+        # A turn can end (completed, stopped, or failed) while a thought is
+        # still buffered; publish it rather than dropping it.
+        with suppress(Exception):
+            await flush_cursor_reasoning()
         manifest_watch_task.cancel()
         with suppress(asyncio.CancelledError):
             await manifest_watch_task

--- a/test_run_cursor.py
+++ b/test_run_cursor.py
@@ -882,10 +882,95 @@ while True:
         ]))
         terminal = next(event for event in events if event["type"] == "turn_finished")
         self.assertTrue(terminal["is_error"])
+        # Deltas are buffered into one reasoning block, so the ceiling is
+        # asserted on retained content rather than event count: the two
+        # deltas admitted before the ceiling are published, and the third
+        # one never reaches durable output.
+        reasoning = [
+            event for event in events if event["type"] == "reasoning_summary"
+        ]
+        self.assertEqual(len(reasoning), 1)
+        self.assertEqual(reasoning[0]["text"], "onetwo")
+        self.assertNotIn("three", reasoning[0]["text"])
+
+    async def test_thinking_deltas_publish_one_block_per_completed_thought(
+        self,
+    ) -> None:
+        # Cursor streams reasoning token-by-token. Publishing each delta as
+        # its own durable event made one thought render as a burst of
+        # answer-looking blocks that the timeline then reconciled away
+        # (the "reasoning flashes then disappears" report).
+        def delta(text: str) -> dict:
+            return {
+                "type": "thinking",
+                "subtype": "delta",
+                "text": text,
+                "session_id": "cursor-sess-test",
+            }
+
+        events = await self._run_script(_event_script([
+            _init_event(),
+            delta("The user wants "),
+            delta("a logo, so I "),
+            delta("will draft one."),
+            {
+                "type": "thinking",
+                "subtype": "completed",
+                "session_id": "cursor-sess-test",
+            },
+            delta("Second thought."),
+            {
+                "type": "thinking",
+                "subtype": "completed",
+                "session_id": "cursor-sess-test",
+            },
+            _result_event(),
+        ]))
+
+        reasoning = [
+            event for event in events if event["type"] == "reasoning_summary"
+        ]
+        self.assertEqual(len(reasoning), 2)
         self.assertEqual(
-            len([event for event in events if event["type"] == "reasoning_summary"]),
-            2,
+            reasoning[0]["text"],
+            "The user wants a logo, so I will draft one.",
         )
+        self.assertEqual(reasoning[1]["text"], "Second thought.")
+
+    async def test_buffered_reasoning_is_published_before_the_answer(
+        self,
+    ) -> None:
+        # Cursor does not always send `thinking/completed`; the pending
+        # thought must still reach the timeline, and must stay ordered
+        # before the answer it produced.
+        events = await self._run_script(_event_script([
+            _init_event(),
+            {
+                "type": "thinking",
+                "subtype": "delta",
+                "text": "Working it out.",
+                "session_id": "cursor-sess-test",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Here it is."}],
+                },
+                "session_id": "cursor-sess-test",
+            },
+            _result_event("Here it is."),
+        ]))
+
+        ordered = [
+            event["type"] for event in events
+            if event["type"] in {"reasoning_summary", "assistant_text"}
+        ]
+        self.assertEqual(ordered, ["reasoning_summary", "assistant_text"])
+        reasoning = next(
+            event for event in events if event["type"] == "reasoning_summary"
+        )
+        self.assertEqual(reasoning["text"], "Working it out.")
 
     async def test_accumulated_assistant_fallback_is_bounded(self) -> None:
         agent_server.CURSOR_ACCUMULATED_TEXT_MAX_CHARS = 10
@@ -1081,6 +1166,41 @@ while True:
         self.assertIn("bounded fork memory sentinel", captured_prompts[1])
         self.assertNotIn("[AgentsDock provider instructions]", captured_prompts[2])
         self.assertNotIn("bounded fork memory sentinel", captured_prompts[2])
+
+
+class CursorFileDeliveryInstructionTests(unittest.TestCase):
+    def test_instructions_route_file_delivery_around_blocked_shell(self) -> None:
+        # Real failure this guards (observed in a live chat): Cursor
+        # generated an image, its publish command was rejected four times by
+        # the permission policy, and it told the user to open the file from
+        # disk instead - the image never reached the chat. Writing the
+        # manifest needs no shell, so it must be named as the route to use
+        # when the publish command cannot run.
+        manifest = Path("/tmp/agentsdock-state/sessions/chat-x/manifest.json")
+        instructions = agent_server.cursor_provider_instructions(
+            "chat-x", {}, manifest
+        )
+
+        self.assertIn(str(manifest), instructions)
+        self.assertIn('{"files":["/absolute/path.ext"]}', instructions)
+        self.assertIn("needs no shell", instructions)
+        self.assertIn("generated images", instructions)
+
+    def test_instruction_hash_changes_so_live_sessions_reinject(self) -> None:
+        # Instructions are only re-sent when their hash changes, so a policy
+        # text change has to move the hash or existing chats keep running on
+        # the old guidance forever.
+        manifest = Path("/tmp/agentsdock-state/sessions/chat-x/manifest.json")
+        with patch.object(
+            agent_server,
+            "CURSOR_FILE_DELIVERY_ADDENDUM",
+            "Delivering files: old guidance.\n",
+        ):
+            previous = agent_server.cursor_instruction_hash(
+                "chat-x", {}, manifest
+            )
+        current = agent_server.cursor_instruction_hash("chat-x", {}, manifest)
+        self.assertNotEqual(previous, current)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two separate user-reported Cursor defects. Both are **server-side** (the client is behaving correctly in each case).

## 1. Reasoning flashed on screen like an answer, then vanished

Cursor streams reasoning as many token-sized `thinking` deltas, and `run_cursor` published **every delta** as its own durable `reasoning_summary` event. Codex publishes exactly one `reasoning_summary` per reasoning item, and the client renders one event as one block — so a single Cursor thought arrived as a burst of answer-looking blocks that the timeline then reconciled away. `reasoning_completed` was parsed but never handled at all.

Deltas are now buffered and published as one event per completed thought, matching the Codex contract. The buffer is also flushed before assistant text and before a tool call (Cursor does not always send `thinking/completed`, and this preserves provider ordering), and in the run's `finally` so a thought is never stranded when a turn ends or is stopped. The existing per-turn character ceiling still applies to the merged block.

## 2. Generated images/files never arrived in the chat

Confirmed from the real failing session: `generateImage` **succeeded**, then Cursor's publish command was rejected four times with `Rejected by permission policy`, and it gave up and told the user to open the file from disk themselves.

Cursor sessions run under a per-session permission mode, and every mode except full access rejects shell outright — so the publish CLI, being a shell command, can never run there. The shared prelude presents that CLI as the *only* sanctioned route and frames the manifest as an "older-server fallback", so a shell-blocked turn had no route left.

Writing the manifest needs no shell (verified live: `--trust` alone can write outside the workspace), so Cursor turns now carry an explicit addendum naming the manifest as the route to use when the publish command is rejected, covering generated images specifically. `CURSOR_PROMPT_POLICY_VERSION` is bumped so live sessions re-inject the new guidance instead of running on the old text forever.

## Test plan

Verified end to end against the **real Cursor CLI** on an isolated test server, in the same `default` permission mode as the failing report:

> Cursor tried the CLI → rejected → reasoned `"Fallback: write manifest."` → wrote it with its file tool → server emitted `artifact_created` and ingested the file.

That is the delivery that previously never happened. Reasoning in that same run arrived as two clean blocks instead of a stream of fragments, confirming both fixes together.

- [x] merged deltas publish one block per completed thought *(fails pre-fix: 4 events instead of 2)*
- [x] a pending thought is published before the answer, in order
- [x] the stream-event ceiling test now asserts retained reasoning **content** rather than event count — a stricter check of the same bound
- [x] file-delivery instructions name the manifest route, and the instruction hash changes so live sessions re-inject
- [x] Full suite: 1629 passed, same pre-existing 47 failures as `origin/main` (installer + team-hub, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)