### PR TITLE
Load the installer config file's environment on both platforms

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -142,6 +142,75 @@ def agentsdock_setting(suffix: str, default: str) -> str:
     return value if value is not None else default
 
 
+CONFIG_ENV_FILE = (
+    Path(
+        os.environ.get("AGENTS_SERVER_CONFIG_DIR")
+        or (Path.home() / ".config" / "agents-server")
+    )
+    / "env"
+)
+CONFIG_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def parse_config_env_file(text: str) -> dict[str, str]:
+    """Parse the installer's `KEY=VALUE` config file, systemd-style.
+
+    Deliberately forgiving: a malformed line is skipped rather than raised,
+    because this runs during import and must never stop the server from
+    starting over one stray hand-edited line.
+    """
+
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        name, separator, value = line.partition("=")
+        name = name.strip()
+        if not separator or not CONFIG_ENV_NAME_RE.fullmatch(name):
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        values[name] = value
+    return values
+
+
+def load_config_env_file(path: Path | None = None) -> list[str]:
+    """Apply installer config-file variables the process does not already have.
+
+    install.sh writes this file and deliberately preserves any extra lines an
+    operator adds to it, and the Linux unit loads it via `EnvironmentFile`.
+    launchd has no equivalent, so on macOS those extra lines - a company
+    provider's `COMPANY_API_KEY`, for example - silently never reached the
+    provider CLI, with nothing reporting that the file was ignored. Reading
+    it here makes both platforms behave the same.
+
+    Existing process variables always win, so values injected by the service
+    manager (access token, state dir, port, PATH) can never be overridden by
+    a stale copy left behind in the file. Returns the names applied, for
+    logging; values are never logged.
+    """
+
+    target = CONFIG_ENV_FILE if path is None else path
+    try:
+        text = target.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return []
+    applied: list[str] = []
+    for name, value in parse_config_env_file(text).items():
+        if name in os.environ:
+            continue
+        os.environ[name] = value
+        applied.append(name)
+    return sorted(applied)
+
+
+CONFIG_ENV_APPLIED = load_config_env_file()
+
+
 def resolve_state_dir() -> Path:
     configured = env_setting(
         "AGENTSDOCK_STATE_DIR",
@@ -49290,6 +49359,14 @@ async def lifespan(app: FastAPI):
     host_monitor_task = asyncio.create_task(host_monitor_loop())
     history_search_task = asyncio.create_task(history_search_index_loop())
     runtime_probe_task = asyncio.create_task(asyncio.to_thread(refresh_runtime_diagnostics, force=True))
+    if CONFIG_ENV_APPLIED:
+        # Names only - these can be provider credentials.
+        logger.info(
+            "loaded %d config-file environment variable(s) from %s: %s",
+            len(CONFIG_ENV_APPLIED),
+            CONFIG_ENV_FILE,
+            ", ".join(CONFIG_ENV_APPLIED),
+        )
     logger.info(
         "agent server ready state=%s sessions=%d jobs=%d digests=%d recovered_scheduled_runs=%d abandoned_turns=%d abandoned_compactions=%d authority_removed=%d queue_recovery=background",
         STATE_DIR,

--- a/test_config_env_file.py
+++ b/test_config_env_file.py
@@ -1,0 +1,135 @@
+"""Config-file environment loading for provider processes.
+
+install.sh writes ~/.config/agents-server/env and deliberately preserves
+operator-added lines in it, and the Linux systemd unit loads it via
+`EnvironmentFile`. launchd has no equivalent, so on macOS those lines were
+written, preserved across upgrades, and then silently ignored - a company
+provider's COMPANY_API_KEY never reached the CLI and the turn failed with
+"Missing environment variable". These cover the server-side loader that
+closes that platform gap.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import agent_server
+
+
+class ParseConfigEnvFileTests(unittest.TestCase):
+    def test_parses_the_installer_written_shape(self) -> None:
+        parsed = agent_server.parse_config_env_file(
+            "AGENTSDOCK_AGENT_PORT=7850\n"
+            "COMPANY_API_KEY=sk-abc123\n"
+        )
+        self.assertEqual(
+            parsed,
+            {"AGENTSDOCK_AGENT_PORT": "7850", "COMPANY_API_KEY": "sk-abc123"},
+        )
+
+    def test_ignores_comments_blanks_and_export_prefixes(self) -> None:
+        parsed = agent_server.parse_config_env_file(
+            "\n"
+            "# a comment\n"
+            "   \n"
+            "export COMPANY_API_KEY=sk-abc123\n"
+        )
+        self.assertEqual(parsed, {"COMPANY_API_KEY": "sk-abc123"})
+
+    def test_strips_matched_surrounding_quotes_only(self) -> None:
+        parsed = agent_server.parse_config_env_file(
+            'A="quoted"\n'
+            "B='single'\n"
+            'C="unbalanced\n'
+            "D=plain=value=with=equals\n"
+        )
+        self.assertEqual(parsed["A"], "quoted")
+        self.assertEqual(parsed["B"], "single")
+        self.assertEqual(parsed["C"], '"unbalanced')
+        self.assertEqual(parsed["D"], "plain=value=with=equals")
+
+    def test_malformed_lines_are_skipped_not_raised(self) -> None:
+        # This runs during import; one stray hand-edited line must never
+        # stop the server from starting.
+        parsed = agent_server.parse_config_env_file(
+            "no-equals-sign\n"
+            "1INVALID_NAME=x\n"
+            "has space=x\n"
+            "GOOD=1\n"
+        )
+        self.assertEqual(parsed, {"GOOD": "1"})
+
+
+class LoadConfigEnvFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.path = Path(self.tempdir.name) / "env"
+        self.touched: list[str] = []
+
+    def _cleanup(self, *names: str) -> None:
+        for name in names:
+            self.addCleanup(os.environ.pop, name, None)
+
+    def test_applies_variables_the_process_does_not_have(self) -> None:
+        self._cleanup("COMPANY_API_KEY")
+        os.environ.pop("COMPANY_API_KEY", None)
+        self.path.write_text("COMPANY_API_KEY=sk-from-file\n", encoding="utf-8")
+
+        applied = agent_server.load_config_env_file(self.path)
+
+        self.assertEqual(applied, ["COMPANY_API_KEY"])
+        self.assertEqual(os.environ["COMPANY_API_KEY"], "sk-from-file")
+
+    def test_never_overrides_a_variable_the_service_manager_set(self) -> None:
+        # The launchd plist / systemd unit injects the real token, port and
+        # PATH. A stale copy in the file must not be able to replace them,
+        # or a leftover value would break an otherwise healthy install.
+        self._cleanup("AGENTSDOCK_AGENT_TOKEN")
+        os.environ["AGENTSDOCK_AGENT_TOKEN"] = "live-token"
+        self.path.write_text(
+            "AGENTSDOCK_AGENT_TOKEN=stale-token\nCOMPANY_API_KEY=sk\n",
+            encoding="utf-8",
+        )
+        self._cleanup("COMPANY_API_KEY")
+        os.environ.pop("COMPANY_API_KEY", None)
+
+        applied = agent_server.load_config_env_file(self.path)
+
+        self.assertEqual(os.environ["AGENTSDOCK_AGENT_TOKEN"], "live-token")
+        self.assertNotIn("AGENTSDOCK_AGENT_TOKEN", applied)
+        self.assertEqual(applied, ["COMPANY_API_KEY"])
+
+    def test_missing_file_is_not_an_error(self) -> None:
+        self.assertEqual(
+            agent_server.load_config_env_file(self.path / "nope" / "env"), []
+        )
+
+    def test_unreadable_file_is_not_an_error(self) -> None:
+        # A directory where the file is expected must not crash startup.
+        directory = Path(self.tempdir.name) / "as-a-directory"
+        directory.mkdir()
+        self.assertEqual(agent_server.load_config_env_file(directory), [])
+
+
+class ProviderEnvironmentTests(unittest.TestCase):
+    def test_loaded_variable_reaches_the_provider_environment(self) -> None:
+        # The whole point: runner_env() is what provider CLIs inherit, so a
+        # config-file variable has to be visible there.
+        self.addCleanup(os.environ.pop, "COMPANY_API_KEY", None)
+        os.environ["COMPANY_API_KEY"] = "sk-from-file"
+        self.assertEqual(
+            agent_server.runner_env().get("COMPANY_API_KEY"), "sk-from-file"
+        )
+
+    def test_agentsdock_secrets_are_still_stripped(self) -> None:
+        # Loading the file must not become a way to smuggle the server's own
+        # bearer token into provider-controlled processes.
+        self.addCleanup(os.environ.pop, "AGENTSDOCK_AGENT_TOKEN", None)
+        os.environ["AGENTSDOCK_AGENT_TOKEN"] = "live-token"
+        self.assertNotIn("AGENTSDOCK_AGENT_TOKEN", agent_server.runner_env())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

A user's company Codex setup kept failing with `Missing environment variable: COMPANY_API_KEY`, even though the same CLI worked fine in their own terminal — so their login really was fine.

Provider CLIs inherit the **server process's** environment (`runner_env`), and a service manager does not source a login shell. So anything exported in `~/.zshrc` is invisible to the service.

## Why the existing config file didn't save them

`install.sh` writes `~/.config/agents-server/env` and **deliberately preserves operator-added lines across upgrades** — that file is clearly meant to hold custom variables. The Linux systemd unit loads it via `EnvironmentFile=`.

launchd has no `EnvironmentFile` equivalent, and the plist we generate carries a fixed key list. So on macOS those lines were written, preserved, and then **silently ignored** — with nothing reporting that the file had no effect. A user could add the variable, see no change, and reasonably conclude they'd got the value wrong.

## The fix

The server reads that file itself at import, before any module-level setting is resolved, so both platforms behave identically and existing Linux configs keep working unchanged.

**Existing process variables always win.** Values injected by the service manager (access token, state dir, bind, port, PATH) can never be replaced by a stale copy left in the file, so this cannot break a healthy install — it only fills in variables the process does not already have.

Parsing is deliberately forgiving because it runs during import: a malformed line is skipped rather than raised, so one stray hand-edited line cannot stop the server from starting. Applied names are logged at startup for support; values never are.

This does not widen what providers can see — `PROVIDER_SECRET_ENV_NAMES` is still stripped from `runner_env`, so the server's own bearer token cannot be smuggled into a provider process through the file.

## Test plan

- [x] Verified live: with a config file containing `COMPANY_API_KEY` **plus** a stale `AGENTSDOCK_AGENT_TOKEN`, the key reaches `runner_env`, the live token injected by the service is kept, and the server's own token is still stripped
- [x] Parsing: installer-written shape, comments/blanks/`export ` prefixes, matched-quote stripping only, malformed lines skipped
- [x] Loading: applies missing variables, never overrides service-manager values, missing file and unreadable path are both non-fatal
- [x] Full suite: 1644 passed, same pre-existing 47 failures as `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)