### PR TITLE
Sync provider messages added outside a chat when the chat is opened

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -46,7 +46,7 @@ import threading
 import time
 import unicodedata
 import uuid
-from collections import OrderedDict, defaultdict, deque
+from collections import Counter, OrderedDict, defaultdict, deque
 from contextlib import asynccontextmanager, contextmanager, suppress
 from datetime import datetime, timezone
 from pathlib import Path
@@ -643,6 +643,12 @@ MAX_ARTIFACT_PUBLISH_FILES = int(agentsdock_setting("ARTIFACT_PUBLISH_MAX_FILES"
 MAX_ARTIFACT_TITLE_CHARS = int(agentsdock_setting("ARTIFACT_TITLE_MAX_CHARS", "1000"))
 MAX_ARTIFACT_TEXT_CHARS = int(agentsdock_setting("ARTIFACT_TEXT_MAX_CHARS", "12000"))
 MAX_IMPORT_MESSAGES = int(agentsdock_setting("HISTORY_IMPORT_LIMIT", "400"))
+# How far back to look for messages already on the timeline when deciding
+# what a provider transcript added elsewhere. Bounded so opening a very long
+# chat cannot turn into an unbounded scan.
+HISTORY_SYNC_EVENT_SCAN_LIMIT = int(
+    agentsdock_setting("HISTORY_SYNC_EVENT_SCAN_LIMIT", "20000")
+)
 MAX_IMPORTED_TEXT_CHARS = int(agentsdock_setting("HISTORY_IMPORT_TEXT_CHARS", "12000"))
 MAX_LOCAL_SESSION_LIST_ITEMS = 500
 MAX_LOCAL_SESSION_SCAN_FILES = 10_000
@@ -8759,6 +8765,9 @@ async def broadcast_committed_emergency_removal(session_id: str) -> None:
 
 ACTIVE: dict[str, dict[str, Any]] = {}
 BUSY_SESSIONS: set[str] = set()
+# Chats with a provider-transcript catch-up already queued or running, so a
+# burst of opens cannot start overlapping syncs of the same chat.
+HISTORY_SYNC_SCHEDULED: set[str] = set()
 # Short provider-maintenance requests (for example, loading a selected Codex
 # thread) participate in update admission without impersonating a user turn in
 # runtime/status responses.
@@ -31642,6 +31651,138 @@ def provider_history(sess: dict[str, Any], limit: int | None) -> tuple[Path | No
     return None, []
 
 
+def history_dedup_key(kind: str, text: Any) -> tuple[str, str]:
+    """Compare a transcript message to a timeline message by shape, not bytes.
+
+    The same message reaches the two sides by different paths (import
+    compaction on one, assistant-text cleaning on the other), so whitespace
+    is normalized before comparing.
+    """
+
+    return str(kind or ""), " ".join(str(text or "").split())
+
+
+def unsynced_history_items(
+    session_id: str,
+    items: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Return only the transcript tail this chat's timeline has not shown.
+
+    A provider transcript holds the whole conversation, including turns this
+    server itself ran, so re-importing it wholesale duplicates everything.
+    This walks the transcript against messages already on the timeline and
+    keeps only what follows the last message we recognize.
+
+    Deliberately anchored to the *last* match rather than to every unmatched
+    item: if one mid-history message fails to match (cleaning differences, an
+    edited transcript), the safe outcome is importing nothing extra rather
+    than splicing a duplicate into the middle of the conversation.
+    """
+
+    seen: Counter[tuple[str, str]] = Counter()
+    for event in read_events(session_id, limit=HISTORY_SYNC_EVENT_SCAN_LIMIT):
+        event_type = event.get("type")
+        if event_type == "turn_started":
+            seen[history_dedup_key("user", event.get("prompt"))] += 1
+        elif event_type == "assistant_text":
+            seen[history_dedup_key("assistant", event.get("text"))] += 1
+
+    last_matched = -1
+    for index, item in enumerate(items):
+        key = history_dedup_key(item.get("kind", ""), item.get("text", ""))
+        if seen.get(key):
+            seen[key] -= 1
+            last_matched = index
+    return items[last_matched + 1:]
+
+
+async def sync_provider_history(
+    sess: dict[str, Any],
+    *,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Append provider messages added outside this chat since the last sync.
+
+    AgentsDock drives the real provider CLI, so anything sent from here is
+    already in the provider transcript - but the reverse was not true. A
+    conversation continued in the provider's own CLI (or on another machine
+    sharing that transcript) grew silently: the next AgentsDock turn resumed
+    the thread and the model answered with full context the timeline never
+    showed, which reads as the assistant knowing things the user never said.
+    """
+
+    session_id = str(sess["id"])
+    if not session_provider_id(sess):
+        return {
+            "imported": 0,
+            "source_path": None,
+            "message": "No provider session ID set.",
+        }
+    source_path, items = await asyncio.to_thread(provider_history, sess, limit)
+    if not source_path or not items:
+        return {
+            "imported": 0,
+            "source_path": None,
+            "message": "No provider transcript found.",
+        }
+    fresh = await asyncio.to_thread(unsynced_history_items, session_id, items)
+    if not fresh:
+        return {
+            "imported": 0,
+            "source_path": str(source_path),
+            "message": "Already up to date with the provider transcript.",
+        }
+    return await append_imported_history(sess, source_path, fresh)
+
+
+async def run_provider_history_sync(session_id: str) -> None:
+    """Sync one chat in the background; never surface failure to the opener."""
+
+    try:
+        sess = STORE.sessions.get(session_id)
+        if not sess:
+            return
+        result = await sync_provider_history(dict(sess))
+        if result.get("imported"):
+            logger.info(
+                "synced %d provider message(s) added outside session=%s",
+                result["imported"],
+                session_id,
+            )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        # A read-only catch-up must never break opening a chat.
+        logger.warning(
+            "provider history sync failed session=%s error=%s",
+            session_id,
+            type(exc).__name__,
+        )
+    finally:
+        HISTORY_SYNC_SCHEDULED.discard(session_id)
+
+
+def schedule_provider_history_sync(sess: dict[str, Any]) -> None:
+    """Catch one chat's transcript up when opened, without blocking the open.
+
+    Opening a chat must stay fast, and the client is already subscribed to
+    the event stream, so recovered messages arrive live instead of delaying
+    the response.
+    """
+
+    session_id = str(sess.get("id") or "")
+    if not session_id or session_id in HISTORY_SYNC_SCHEDULED:
+        return
+    if not session_provider_id(sess):
+        return
+    # A turn in flight is already streaming the provider's own output and its
+    # transcript writes are still landing.
+    if session_id in BUSY_SESSIONS or ACTIVE.get(session_id) is not None:
+        return
+    HISTORY_SYNC_SCHEDULED.add(session_id)
+    asyncio.create_task(run_provider_history_sync(session_id))
+
+
 async def append_imported_history(
     sess: dict[str, Any],
     source_path: Path,
@@ -52513,6 +52654,11 @@ async def get_session(
     sess = STORE.sessions.get(session_id)
     if not sess:
         raise HTTPException(status_code=404, detail="session not found")
+    # Opening a chat is the moment to notice that its provider transcript grew
+    # somewhere else (the provider's own CLI, or another machine sharing it).
+    # Scheduled rather than awaited so the open stays fast; the client's event
+    # stream delivers whatever it recovers.
+    schedule_provider_history_sync(sess)
     normalized_page_mode = str(page_mode or "").strip().lower()
     if normalized_page_mode not in {"", "semantic"}:
         raise HTTPException(status_code=400, detail="page_mode must be semantic")

--- a/test_provider_history_sync.py
+++ b/test_provider_history_sync.py
@@ -1,0 +1,281 @@
+"""Catching a chat up with provider messages added outside AgentsDock.
+
+Importing a remote conversation used to be a one-time snapshot: continuing it
+in the provider's own CLI grew the transcript, AgentsDock never noticed, and
+the next AgentsDock turn resumed the thread so the model answered with full
+context the timeline had never shown. Re-importing was no fix either - it had
+no dedup and appended the whole conversation a second time.
+"""
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import agent_server
+
+
+def user(text: str) -> dict[str, str]:
+    return {"kind": "user", "text": text}
+
+
+def assistant(text: str) -> dict[str, str]:
+    return {"kind": "assistant", "text": text}
+
+
+class UnsyncedHistoryItemsTests(unittest.TestCase):
+    """Pure selection logic: what does the timeline not have yet?"""
+
+    def select(self, events, items):
+        with patch.object(agent_server, "read_events", return_value=events):
+            return agent_server.unsynced_history_items("chat-x", items)
+
+    def test_nothing_new_when_the_timeline_already_shows_it_all(self) -> None:
+        events = [
+            {"type": "turn_started", "prompt": "hello"},
+            {"type": "assistant_text", "text": "hi there"},
+        ]
+        self.assertEqual(
+            self.select(events, [user("hello"), assistant("hi there")]), []
+        )
+
+    def test_returns_only_the_tail_added_elsewhere(self) -> None:
+        events = [
+            {"type": "turn_started", "prompt": "hello"},
+            {"type": "assistant_text", "text": "hi there"},
+        ]
+        fresh = self.select(
+            events,
+            [
+                user("hello"),
+                assistant("hi there"),
+                user("continued in the CLI"),
+                assistant("answered in the CLI"),
+            ],
+        )
+        self.assertEqual(
+            fresh, [user("continued in the CLI"), assistant("answered in the CLI")]
+        )
+
+    def test_everything_is_new_for_an_empty_timeline(self) -> None:
+        self.assertEqual(
+            self.select([], [user("hello"), assistant("hi")]),
+            [user("hello"), assistant("hi")],
+        )
+
+    def test_whitespace_differences_still_count_as_the_same_message(self) -> None:
+        # The two sides reach the timeline through different cleaning paths.
+        events = [{"type": "assistant_text", "text": "hi   there\n\n"}]
+        self.assertEqual(self.select(events, [assistant("hi there")]), [])
+
+    def test_a_repeated_message_is_matched_once_per_occurrence(self) -> None:
+        # "continue" sent twice must not make the second one look already
+        # imported.
+        events = [
+            {"type": "turn_started", "prompt": "continue"},
+            {"type": "assistant_text", "text": "ok"},
+        ]
+        fresh = self.select(
+            events, [user("continue"), assistant("ok"), user("continue")]
+        )
+        self.assertEqual(fresh, [user("continue")])
+
+    def test_a_mid_history_mismatch_never_splices_a_duplicate(self) -> None:
+        # If an older message fails to match, the safe outcome is importing
+        # nothing extra - not re-inserting it in the middle of the chat.
+        events = [
+            {"type": "turn_started", "prompt": "hello"},
+            {"type": "assistant_text", "text": "TIMELINE VERSION"},
+            {"type": "turn_started", "prompt": "second"},
+            {"type": "assistant_text", "text": "second reply"},
+        ]
+        fresh = self.select(
+            events,
+            [
+                user("hello"),
+                assistant("TRANSCRIPT VERSION"),
+                user("second"),
+                assistant("second reply"),
+            ],
+        )
+        self.assertEqual(fresh, [])
+
+    def test_turns_run_by_agentsdock_are_not_re_imported(self) -> None:
+        # The transcript also contains everything this server ran itself.
+        events = [
+            {"type": "turn_started", "prompt": "asked from AgentsDock"},
+            {"type": "assistant_text", "text": "answered to AgentsDock"},
+        ]
+        self.assertEqual(
+            self.select(
+                events,
+                [user("asked from AgentsDock"), assistant("answered to AgentsDock")],
+            ),
+            [],
+        )
+
+
+class SyncProviderHistoryTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.transcript = Path(self.tempdir.name) / "rollout.jsonl"
+        self.transcript.write_text("", encoding="utf-8")
+        self.sess = {
+            "id": "chat-sync",
+            "backend": agent_server.BACKEND_CODEX,
+            "codex_thread_id": "thread-1",
+        }
+
+    async def test_appends_only_the_externally_added_tail(self) -> None:
+        items = [
+            user("hello"),
+            assistant("hi there"),
+            user("continued in the CLI"),
+            assistant("answered in the CLI"),
+        ]
+        events = [
+            {"type": "turn_started", "prompt": "hello"},
+            {"type": "assistant_text", "text": "hi there"},
+        ]
+        appended: list[tuple[str, dict]] = []
+
+        async def fake_append(session_id, event_type, payload=None):
+            appended.append((event_type, payload or {}))
+            return {}
+
+        with patch.object(
+            agent_server, "provider_history", return_value=(self.transcript, items)
+        ), patch.object(
+            agent_server, "read_events", return_value=events
+        ), patch.object(
+            agent_server, "append_event", fake_append
+        ):
+            result = await agent_server.sync_provider_history(self.sess)
+
+        self.assertEqual(result["imported"], 2)
+        prompts = [p.get("prompt") for t, p in appended if t == "turn_started"]
+        texts = [p.get("text") for t, p in appended if t == "assistant_text"]
+        self.assertEqual(prompts, ["continued in the CLI"])
+        self.assertEqual(texts, ["answered in the CLI"])
+        # The already-shown opening must not be replayed.
+        self.assertNotIn("hello", prompts)
+        self.assertNotIn("hi there", texts)
+
+    async def test_up_to_date_transcript_appends_nothing_at_all(self) -> None:
+        # Opening a chat repeatedly must not keep adding landmark events.
+        items = [user("hello"), assistant("hi there")]
+        events = [
+            {"type": "turn_started", "prompt": "hello"},
+            {"type": "assistant_text", "text": "hi there"},
+        ]
+        appended: list[str] = []
+
+        async def fake_append(session_id, event_type, payload=None):
+            appended.append(event_type)
+            return {}
+
+        with patch.object(
+            agent_server, "provider_history", return_value=(self.transcript, items)
+        ), patch.object(
+            agent_server, "read_events", return_value=events
+        ), patch.object(
+            agent_server, "append_event", fake_append
+        ):
+            result = await agent_server.sync_provider_history(self.sess)
+
+        self.assertEqual(result["imported"], 0)
+        self.assertEqual(appended, [])
+
+    async def test_session_without_a_provider_id_is_skipped(self) -> None:
+        result = await agent_server.sync_provider_history(
+            {"id": "chat-none", "backend": agent_server.BACKEND_CODEX}
+        )
+        self.assertEqual(result["imported"], 0)
+
+
+class ScheduleProviderHistorySyncTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.previous_scheduled = set(agent_server.HISTORY_SYNC_SCHEDULED)
+        self.previous_busy = agent_server.BUSY_SESSIONS
+        self.previous_active = agent_server.ACTIVE
+        agent_server.HISTORY_SYNC_SCHEDULED.clear()
+        agent_server.BUSY_SESSIONS = set()
+        agent_server.ACTIVE = {}
+
+    async def asyncTearDown(self) -> None:
+        agent_server.HISTORY_SYNC_SCHEDULED.clear()
+        agent_server.HISTORY_SYNC_SCHEDULED.update(self.previous_scheduled)
+        agent_server.BUSY_SESSIONS = self.previous_busy
+        agent_server.ACTIVE = self.previous_active
+
+    def sess(self) -> dict:
+        return {
+            "id": "chat-open",
+            "backend": agent_server.BACKEND_CODEX,
+            "codex_thread_id": "thread-1",
+        }
+
+    async def test_repeated_opens_do_not_start_overlapping_syncs(self) -> None:
+        started = 0
+
+        async def fake_run(session_id):
+            nonlocal started
+            started += 1
+            await asyncio.sleep(0)
+
+        with patch.object(agent_server, "run_provider_history_sync", fake_run):
+            for _ in range(5):
+                agent_server.schedule_provider_history_sync(self.sess())
+            await asyncio.sleep(0)
+
+        self.assertEqual(started, 1)
+
+    async def test_busy_session_is_left_alone(self) -> None:
+        # A live turn is already streaming provider output and still writing
+        # its transcript.
+        agent_server.BUSY_SESSIONS = {"chat-open"}
+        started = False
+
+        async def fake_run(session_id):
+            nonlocal started
+            started = True
+
+        with patch.object(agent_server, "run_provider_history_sync", fake_run):
+            agent_server.schedule_provider_history_sync(self.sess())
+            await asyncio.sleep(0)
+
+        self.assertFalse(started)
+
+    async def test_session_without_provider_id_is_not_scheduled(self) -> None:
+        started = False
+
+        async def fake_run(session_id):
+            nonlocal started
+            started = True
+
+        with patch.object(agent_server, "run_provider_history_sync", fake_run):
+            agent_server.schedule_provider_history_sync(
+                {"id": "chat-open", "backend": agent_server.BACKEND_CODEX}
+            )
+            await asyncio.sleep(0)
+
+        self.assertFalse(started)
+
+    async def test_a_failing_sync_clears_its_slot_so_a_later_open_retries(
+        self,
+    ) -> None:
+        async def boom(sess, **kwargs):
+            raise RuntimeError("transcript unreadable")
+
+        with patch.object(agent_server.STORE, "sessions", {"chat-open": self.sess()}), \
+                patch.object(agent_server, "sync_provider_history", boom):
+            agent_server.HISTORY_SYNC_SCHEDULED.add("chat-open")
+            await agent_server.run_provider_history_sync("chat-open")
+
+        self.assertNotIn("chat-open", agent_server.HISTORY_SYNC_SCHEDULED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The report

> "I imported a remote conversation to this computer, but my later chat history from the remote Codex didn't sync over."

## What was actually happening

Import was a **one-time snapshot**. Continuing that conversation in the provider's own CLI grew the provider transcript, and AgentsDock never looked at it again — nothing polls it, and the only reader tails it *during* a turn this server is already running.

The genuinely confusing part is what happens next. AgentsDock resumes the provider thread by id, so **the provider still has the full context**. The next turn answers using messages the timeline never showed — which reads as the assistant knowing things the user never said here.

Re-importing was not a fix either: the existing force path appends every transcript message unconditionally, so it duplicated the whole conversation instead of catching up.

Note the asymmetry this closes — AgentsDock → provider always worked (we drive the real CLI, so our turns land in the same transcript). Only provider → AgentsDock was missing.

## The fix

Opening a chat schedules a bounded catch-up that appends **only the transcript tail the timeline has not shown**.

Selection walks the transcript against messages already on the timeline and keeps what follows the last message it recognizes, comparing on whitespace-normalized text because the two sides arrive through different cleaning paths. **Anchoring to the last match is deliberate**: if a mid-history message fails to match, the safe outcome is importing nothing extra rather than splicing a duplicate into the middle of a conversation. Turns this server ran itself are in the transcript too and are matched the same way, so they are never re-imported.

Operationally:
- **Scheduled, not awaited** — opening a chat stays fast, and the client is already subscribed to the event stream, so recovered messages arrive live
- Repeat opens cannot start overlapping syncs of the same chat
- A chat with a turn in flight is skipped (its transcript writes are still landing)
- Any failure is logged and clears its slot, so a later open retries instead of breaking the open

## Test plan

- [x] Verified end to end against a real transcript and real event storage: import 2 messages → append 2 more to the transcript out of band → open again and **exactly those 2** arrive → open once more and **nothing** is added
- [x] Selection: nothing new when up to date; only the externally-added tail; everything for an empty timeline; whitespace-only differences match; a repeated message ("continue" twice) is matched once per occurrence; a mid-history mismatch never splices a duplicate; AgentsDock's own turns are not re-imported
- [x] Scheduling: repeat opens start one sync; busy sessions skipped; sessions without a provider id skipped; a failing sync clears its slot so a later open retries
- [x] Full suite: 1648 passed, same pre-existing 47 failures as `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)