### PR TITLE
Make Cursor beta.17 release tests portable on Linux

### DIFF
--- a/test_cursor_process_guard.py
+++ b/test_cursor_process_guard.py
@@ -169,8 +169,12 @@ class CursorProcessGuardTests(unittest.TestCase):
             )
             leader = root / "normal-leader.py"
             leader.write_text(
-                "import subprocess, sys\n"
-                f"subprocess.Popen([sys.executable, {str(descendant)!r}])\n",
+                "import pathlib, subprocess, sys, time\n"
+                f"pid_file = pathlib.Path({str(pid_file)!r})\n"
+                f"subprocess.Popen([sys.executable, {str(descendant)!r}])\n"
+                "deadline = time.monotonic() + 3\n"
+                "while not pid_file.exists() and time.monotonic() < deadline:\n"
+                "    time.sleep(0.02)\n",
                 encoding="utf-8",
             )
             guard_script = Path(__file__).with_name("cursor_process_guard.py")

--- a/test_runtime_diagnostics.py
+++ b/test_runtime_diagnostics.py
@@ -197,7 +197,7 @@ class RuntimeDiagnosticTests(unittest.TestCase):
                 agent_server.cursor_executable_resolution()
             )
         self.assertIsNone(compatible)
-        self.assertEqual(installed, "/bin/agent")
+        self.assertEqual(installed, str(Path("/bin/agent").resolve()))
         self.assertEqual(missing, ())
         self.assertEqual(error, "identity probe did not identify Cursor CLI")
         self.assertNotIn("Grok", error)


### PR DESCRIPTION
## Summary
- wait for the same-process-group Cursor child to initialize before testing guard teardown
- compare the resolved Cursor executable path across platforms where /bin aliases /usr/bin

## Validation
- both formerly failing cases pass
- full suite: 1783 passed, 4 skipped