### PR TITLE
Harden Team Messages persistence and Claude model discovery

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -45,6 +45,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import urllib.request
 import uuid
 from collections import Counter, OrderedDict, defaultdict, deque
 from contextlib import asynccontextmanager, contextmanager, suppress
@@ -560,6 +561,33 @@ CODEX_APP_SERVER_MAX_LOADED_THREADS = max(
 CODEX_RESUME_ACTIVITY_TIMEOUT_SECONDS = int(agentsdock_setting("CODEX_RESUME_ACTIVITY_TIMEOUT_SECONDS", "120"))
 RUNTIME_CATALOG_TIMEOUT_SECONDS = float(agentsdock_setting("RUNTIME_CATALOG_TIMEOUT_SECONDS", "6"))
 RUNTIME_DIAGNOSTIC_TTL_SECONDS = float(agentsdock_setting("RUNTIME_DIAGNOSTIC_TTL_SECONDS", "60"))
+# Claude Code only promises the family aliases in ``--help``; account-scoped
+# pinned models come from Anthropic's Models API when an API key is available.
+# These entries are therefore a last-resort catalog for OAuth/third-party
+# Claude Code installs, not the primary source of truth. Keep the aliases so a
+# newly released model remains selectable even before this fallback is updated.
+CLAUDE_CLI_MODEL_ALIASES = (
+    ("fable", "Fable"),
+    ("opus", "Opus"),
+    ("sonnet", "Sonnet"),
+    ("haiku", "Haiku"),
+    ("opus[1m]", "Opus 1M"),
+    ("claude-opus-4-8[1m]", "Opus 4.8 1M"),
+)
+CLAUDE_CURRENT_MODEL_FALLBACKS = (
+    ("claude-fable-5-1", "Fable 5.1", False),
+    ("claude-mythos-5-1", "Mythos 5.1 (limited access)", True),
+    ("claude-opus-5", "Opus 5", False),
+    ("claude-sonnet-5", "Sonnet 5", False),
+    ("claude-haiku-4-5-20251001", "Haiku 4.5", False),
+)
+CLAUDE_LEGACY_MODEL_FALLBACKS = (
+    ("claude-fable-5", "Fable 5", False),
+    ("claude-mythos-5", "Mythos 5 (limited access)", True),
+    ("claude-opus-4-8", "Opus 4.8", False),
+)
+CLAUDE_MODEL_VALUE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\-\[\]]{0,255}$")
+CLAUDE_MODELS_API_MAX_BYTES = 2 * 1024 * 1024
 JOB_SCHEDULER_INTERVAL_SECONDS = float(agentsdock_setting("JOB_SCHEDULER_INTERVAL_SECONDS", "5"))
 JOB_BUSY_RETRY_SECONDS = int(agentsdock_setting("JOB_BUSY_RETRY_SECONDS", "60"))
 # Zero means scheduled jobs have no scheduler-specific concurrency ceiling.
@@ -40689,10 +40717,16 @@ def title_model_label(value: str) -> str:
         return "Server default"
     known = {
         "fable": "Fable",
+        "claude-fable-5-1": "Fable 5.1",
         "claude-fable-5": "Fable 5",
+        "claude-mythos-5-1": "Mythos 5.1",
+        "claude-mythos-5": "Mythos 5",
+        "claude-opus-5": "Opus 5",
         "opus[1m]": "Opus 1M",
         "claude-opus-4-8": "Opus 4.8",
         "claude-opus-4-8[1m]": "Opus 4.8 1M",
+        "claude-sonnet-5": "Sonnet 5",
+        "claude-haiku-4-5-20251001": "Haiku 4.5",
     }
     if clean.lower() in known:
         return known[clean.lower()]
@@ -41606,11 +41640,142 @@ def discover_codex_catalog() -> dict[str, Any]:
     }
 
 
+def parse_claude_help_model_options(help_text: str) -> list[dict[str, Any]]:
+    """Extract every model token advertised by Claude Code's public help.
+
+    Claude Code currently documents evergreen aliases and one full-name
+    example in the wrapped ``--model`` option. The old parser stopped at the
+    first parenthesized clause, so it silently dropped the full model ID.
+    Restrict parsing to that option block so quoted examples elsewhere in the
+    help cannot become model choices.
+    """
+
+    match = re.search(
+        r"(?ms)^[ \t]*(?:-[A-Za-z],\s*)?--model\s+<model>(?P<body>.*?)"
+        r"(?=^[ \t]*(?:-[A-Za-z],\s*)?--[A-Za-z][A-Za-z0-9-]*(?:[ \t,<]|$)|\Z)",
+        str(help_text or ""),
+    )
+    if match is None:
+        return []
+    options: list[dict[str, Any]] = []
+    for value in re.findall(
+        r"(?<![A-Za-z0-9])['\"`]([A-Za-z0-9][A-Za-z0-9._:/\-\[\]]{0,255})['\"`]",
+        match.group("body"),
+    ):
+        clean = value.strip()
+        if CLAUDE_MODEL_VALUE_RE.fullmatch(clean):
+            options.append(runtime_option(clean, title_model_label(clean)))
+    return options
+
+
+def parse_claude_models_api_payload(payload: Any) -> list[dict[str, Any]]:
+    """Normalize the account-scoped response from Anthropic's Models API."""
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        return []
+    options: list[dict[str, Any]] = []
+    for raw_model in payload["data"]:
+        if not isinstance(raw_model, dict):
+            continue
+        model_id = str(raw_model.get("id") or "").strip()
+        if not CLAUDE_MODEL_VALUE_RE.fullmatch(model_id):
+            continue
+        display_name = str(raw_model.get("display_name") or "").strip()
+        options.append(
+            runtime_option(
+                model_id,
+                display_name[:160] or title_model_label(model_id),
+            )
+        )
+    return options
+
+
+class ClaudeCatalogNoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Never forward an Anthropic API key across an HTTP redirect."""
+
+    def redirect_request(
+        self,
+        req: Any,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def discover_claude_provider_models() -> list[dict[str, Any]]:
+    """Return models available to the configured Anthropic API account.
+
+    Claude subscription/OAuth installs do not expose a model-list command, so
+    they fall through without network access. API-key installs can use the
+    official account-scoped Models API; failures remain non-fatal and never
+    log the credential or a response body.
+    """
+
+    api_key = str(os.environ.get("ANTHROPIC_API_KEY") or "").strip()
+    if not api_key:
+        return []
+    base_url = str(
+        os.environ.get("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"
+    ).strip().rstrip("/")
+    parsed_base = urlparse(base_url)
+    if parsed_base.scheme not in {"http", "https"} or not parsed_base.netloc:
+        logger.warning("claude provider model discovery skipped: invalid base URL")
+        return []
+    endpoint = (
+        f"{base_url}/models?limit=1000"
+        if parsed_base.path.rstrip("/").endswith("/v1")
+        else f"{base_url}/v1/models?limit=1000"
+    )
+    request = urllib.request.Request(
+        endpoint,
+        headers={
+            "anthropic-version": "2023-06-01",
+            "x-api-key": api_key,
+            "accept": "application/json",
+            "user-agent": f"AgentsServer/{SERVER_VERSION}",
+        },
+        method="GET",
+    )
+    try:
+        opener = urllib.request.build_opener(ClaudeCatalogNoRedirectHandler())
+        with opener.open(
+            request,
+            timeout=max(0.5, min(RUNTIME_CATALOG_TIMEOUT_SECONDS, 6.0)),
+        ) as response:
+            raw = response.read(CLAUDE_MODELS_API_MAX_BYTES + 1)
+        if len(raw) > CLAUDE_MODELS_API_MAX_BYTES:
+            raise ValueError("Claude Models API response exceeds size limit")
+        return parse_claude_models_api_payload(json.loads(raw.decode("utf-8")))
+    except Exception as exc:
+        logger.warning(
+            "claude provider model discovery failed error_type=%s",
+            type(exc).__name__,
+        )
+        return []
+
+
+def claude_fallback_model_options() -> list[dict[str, Any]]:
+    options = [runtime_option(value, label) for value, label in CLAUDE_CLI_MODEL_ALIASES]
+    options.extend(
+        runtime_option(
+            value,
+            label,
+            **({"availability": "limited"} if limited else {}),
+        )
+        for value, label, limited in (
+            *CLAUDE_CURRENT_MODEL_FALLBACKS,
+            *CLAUDE_LEGACY_MODEL_FALLBACKS,
+        )
+    )
+    return options
+
+
 def parse_claude_help_catalog() -> dict[str, Any]:
-    model_options: list[dict[str, str]] = []
-    effort_options: list[dict[str, str]] = []
-    model_source = "claude --help"
-    effort_source = "claude --help"
+    model_options: list[dict[str, Any]] = []
+    effort_options: list[dict[str, Any]] = []
     default_model = (
         os.environ.get("CLAUDE_MODEL")
         or os.environ.get("ANTHROPIC_MODEL")
@@ -41619,57 +41784,43 @@ def parse_claude_help_catalog() -> dict[str, Any]:
     )
     default_effort = os.environ.get("CLAUDE_EFFORT") or agentsdock_setting("CLAUDE_EFFORT", "")
     supports_ultracode = claude_supports_effort("ultracode")
+    provider_options = discover_claude_provider_models()
+    help_text = ""
+    help_available = False
     try:
         help_text = run_catalog_command([CLAUDE_BIN, "--help"])
+        help_available = True
     except Exception as exc:
-        logger.warning("claude model discovery failed: %s", exc)
-        return {
-            "models": unique_runtime_options(
-                [
-                    runtime_option("fable", "Fable"),
-                    runtime_option("claude-fable-5", "Fable 5"),
-                    runtime_option("sonnet", "Sonnet"),
-                    runtime_option("opus", "Opus"),
-                    runtime_option("opus[1m]", "Opus 1M"),
-                    runtime_option("claude-opus-4-8", "Opus 4.8"),
-                    runtime_option("claude-opus-4-8[1m]", "Opus 4.8 1M"),
-                    runtime_option("haiku", "Haiku"),
-                ],
-                title_model_label(default_model),
-            ),
-            "efforts": unique_runtime_options(
-                [
-                    runtime_option("low", "Low"),
-                    runtime_option("medium", "Medium"),
-                    runtime_option("high", "High"),
-                    runtime_option("xhigh", "XHigh"),
-                    runtime_option("max", "Max"),
-                    *([runtime_option("ultracode", "Ultracode")] if supports_ultracode else []),
-                ],
-                title_effort_label(default_effort) if default_effort else "",
-            ),
-            "model_source": f"{model_source} failed",
-            "effort_source": f"{effort_source} failed",
-            "default_model": default_model,
-            "default_effort": default_effort or None,
-        }
+        logger.warning(
+            "claude help model discovery failed error_type=%s",
+            type(exc).__name__,
+        )
 
-    model_match = re.search(r"--model <model>.*?\((?:e\.g\.\s*)?([^)]+)\)", help_text, re.IGNORECASE | re.DOTALL)
-    if model_match:
-        aliases = re.findall(r"'([^']+)'", model_match.group(1))
-        for alias in aliases:
-            model_options.append(runtime_option(alias, title_model_label(alias)))
-    for alias, label in (
-        ("fable", "Fable"),
-        ("claude-fable-5", "Fable 5"),
-        ("sonnet", "Sonnet"),
-        ("opus", "Opus"),
-        ("opus[1m]", "Opus 1M"),
-        ("claude-opus-4-8", "Opus 4.8"),
-        ("claude-opus-4-8[1m]", "Opus 4.8 1M"),
-        ("haiku", "Haiku"),
+    discovered_help_options = parse_claude_help_model_options(help_text)
+    # Alias pointers remain first: unlike pinned fallback IDs, they follow a
+    # new Claude release without requiring an AgentsServer update.
+    model_options.extend(
+        option
+        for option in discovered_help_options
+        if not str(option.get("value") or "").startswith("claude-")
+    )
+    model_options.extend(runtime_option(value, label) for value, label in CLAUDE_CLI_MODEL_ALIASES)
+    if provider_options:
+        # The API is account-scoped, so do not add pinned models that this
+        # credential did not return (notably limited-access Mythos models).
+        model_options.extend(provider_options)
+    else:
+        model_options.extend(claude_fallback_model_options())
+    model_options.extend(
+        option
+        for option in discovered_help_options
+        if str(option.get("value") or "").startswith("claude-")
+    )
+    if default_model and not any(
+        str(option.get("value") or "") == default_model
+        for option in model_options
     ):
-        model_options.append(runtime_option(alias, label))
+        model_options.insert(0, runtime_option(default_model, title_model_label(default_model)))
 
     effort_match = re.search(r"--effort\s+<level>.*?\(([^)]+)\)", help_text, re.IGNORECASE | re.DOTALL)
     if effort_match:
@@ -41677,13 +41828,25 @@ def parse_claude_help_catalog() -> dict[str, Any]:
             clean = effort.strip()
             if clean and re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", clean):
                 effort_options.append(runtime_option(clean, title_effort_label(clean)))
+    if not effort_options:
+        effort_options.extend(
+            runtime_option(effort, title_effort_label(effort))
+            for effort in ("low", "medium", "high", "xhigh", "max")
+        )
     if supports_ultracode:
         effort_options.append(runtime_option("ultracode", "Ultracode"))
 
+    model_sources = []
+    if provider_options:
+        model_sources.append("Anthropic Models API")
+    model_sources.append("claude --help" if help_available else "claude --help failed")
+    if not provider_options:
+        model_sources.append("current fallback")
+    effort_source = "claude --help" if help_available else "claude --help failed"
     return {
         "models": unique_runtime_options(model_options, title_model_label(default_model)),
         "efforts": unique_runtime_options(effort_options, title_effort_label(default_effort) if default_effort else ""),
-        "model_source": model_source,
+        "model_source": " + ".join(model_sources),
         "effort_source": effort_source,
         "default_model": default_model,
         "default_effort": default_effort or None,

--- a/agent_server.py
+++ b/agent_server.py
@@ -41791,9 +41791,13 @@ def discover_claude_provider_models(
         child_env = runner_env()
         for secret_name in CLAUDE_PROVIDER_SECRET_ENV_NAMES:
             child_env.pop(secret_name, None)
-        result = subprocess.run(
+        curl_args = [curl_bin, "--disable"]
+        if parsed_base.scheme == "http":
+            # Plain HTTP is allowed only for loopback. Never let inherited
+            # proxy settings send that credential-bearing request elsewhere.
+            curl_args.extend(["--noproxy", "*"])
+        curl_args.extend(
             [
-                curl_bin,
                 "--fail",
                 "--silent",
                 "--show-error",
@@ -41808,7 +41812,10 @@ def discover_claude_provider_models(
                 "--user-agent",
                 f"AgentsServer/{SERVER_VERSION}",
                 endpoint,
-            ],
+            ]
+        )
+        result = subprocess.run(
+            curl_args,
             cwd=DEFAULT_CWD if Path(DEFAULT_CWD).exists() else str(Path.home()),
             env=child_env,
             input=header_bytes,

--- a/agent_server.py
+++ b/agent_server.py
@@ -45,7 +45,6 @@ import tempfile
 import threading
 import time
 import unicodedata
-import urllib.request
 import uuid
 from collections import Counter, OrderedDict, defaultdict, deque
 from contextlib import asynccontextmanager, contextmanager, suppress
@@ -572,7 +571,6 @@ CLAUDE_CLI_MODEL_ALIASES = (
     ("sonnet", "Sonnet"),
     ("haiku", "Haiku"),
     ("opus[1m]", "Opus 1M"),
-    ("claude-opus-4-8[1m]", "Opus 4.8 1M"),
 )
 CLAUDE_CURRENT_MODEL_FALLBACKS = (
     ("claude-fable-5-1", "Fable 5.1", False),
@@ -585,9 +583,15 @@ CLAUDE_LEGACY_MODEL_FALLBACKS = (
     ("claude-fable-5", "Fable 5", False),
     ("claude-mythos-5", "Mythos 5 (limited access)", True),
     ("claude-opus-4-8", "Opus 4.8", False),
+    ("claude-opus-4-8[1m]", "Opus 4.8 1M", False),
 )
 CLAUDE_MODEL_VALUE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/\-\[\]]{0,255}$")
 CLAUDE_MODELS_API_MAX_BYTES = 2 * 1024 * 1024
+CLAUDE_PROVIDER_SECRET_ENV_NAMES = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+)
 JOB_SCHEDULER_INTERVAL_SECONDS = float(agentsdock_setting("JOB_SCHEDULER_INTERVAL_SECONDS", "5"))
 JOB_BUSY_RETRY_SECONDS = int(agentsdock_setting("JOB_BUSY_RETRY_SECONDS", "60"))
 # Zero means scheduled jobs have no scheduler-specific concurrency ceiling.
@@ -41640,8 +41644,10 @@ def discover_codex_catalog() -> dict[str, Any]:
     }
 
 
-def parse_claude_help_model_options(help_text: str) -> list[dict[str, Any]]:
-    """Extract every model token advertised by Claude Code's public help.
+def parse_claude_help_model_option_groups(
+    help_text: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Extract alias and full-name groups from Claude Code's public help.
 
     Claude Code currently documents evergreen aliases and one full-name
     example in the wrapped ``--model`` option. The old parser stopped at the
@@ -41656,16 +41662,49 @@ def parse_claude_help_model_options(help_text: str) -> list[dict[str, Any]]:
         str(help_text or ""),
     )
     if match is None:
-        return []
-    options: list[dict[str, Any]] = []
-    for value in re.findall(
-        r"(?<![A-Za-z0-9])['\"`]([A-Za-z0-9][A-Za-z0-9._:/\-\[\]]{0,255})['\"`]",
-        match.group("body"),
-    ):
-        clean = value.strip()
-        if CLAUDE_MODEL_VALUE_RE.fullmatch(clean):
-            options.append(runtime_option(clean, title_model_label(clean)))
-    return options
+        return [], []
+
+    body = match.group("body")
+    full_name_marker = re.search(
+        r"\bor\s+(?:a\s+)?model(?:'s)?\s+full\s+name\b",
+        body,
+        re.IGNORECASE,
+    )
+    token_re = re.compile(
+        r"(?<![A-Za-z0-9])['\"`]([A-Za-z0-9][A-Za-z0-9._:/\-\[\]]{0,255})['\"`]"
+    )
+
+    def options_from(region: str) -> list[dict[str, Any]]:
+        return [
+            runtime_option(value, title_model_label(value))
+            for value in token_re.findall(region)
+            if CLAUDE_MODEL_VALUE_RE.fullmatch(value)
+        ]
+
+    if full_name_marker is not None:
+        return (
+            options_from(body[:full_name_marker.start()]),
+            options_from(body[full_name_marker.end():]),
+        )
+
+    # Older help has no explicit separator. Short identifier-like values are
+    # aliases; provider/platform IDs contain punctuation and remain full names.
+    alias_options: list[dict[str, Any]] = []
+    full_name_options: list[dict[str, Any]] = []
+    for option in options_from(body):
+        value = str(option.get("value") or "")
+        target = (
+            alias_options
+            if re.fullmatch(r"[a-z][a-z0-9_]*(?:\[[a-z0-9]+\])?", value)
+            else full_name_options
+        )
+        target.append(option)
+    return alias_options, full_name_options
+
+
+def parse_claude_help_model_options(help_text: str) -> list[dict[str, Any]]:
+    aliases, full_names = parse_claude_help_model_option_groups(help_text)
+    return [*aliases, *full_names]
 
 
 def parse_claude_models_api_payload(payload: Any) -> list[dict[str, Any]]:
@@ -41690,22 +41729,24 @@ def parse_claude_models_api_payload(payload: Any) -> list[dict[str, Any]]:
     return options
 
 
-class ClaudeCatalogNoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Never forward an Anthropic API key across an HTTP redirect."""
+def claude_models_api_base_url_allowed(parsed_base: Any) -> bool:
+    """Allow credentials over HTTPS, or plain HTTP only to loopback."""
 
-    def redirect_request(
-        self,
-        req: Any,
-        fp: Any,
-        code: int,
-        msg: str,
-        headers: Any,
-        newurl: str,
-    ) -> None:
-        return None
+    if parsed_base.scheme == "https" and parsed_base.hostname:
+        return True
+    if parsed_base.scheme != "http" or not parsed_base.hostname:
+        return False
+    host = parsed_base.hostname.rstrip(".").lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
-def discover_claude_provider_models() -> list[dict[str, Any]]:
+def discover_claude_provider_models(
+) -> tuple[list[dict[str, Any]], Literal["unavailable", "success", "failed"]]:
     """Return models available to the configured Anthropic API account.
 
     Claude subscription/OAuth installs do not expose a model-list command, so
@@ -41716,50 +41757,85 @@ def discover_claude_provider_models() -> list[dict[str, Any]]:
 
     api_key = str(os.environ.get("ANTHROPIC_API_KEY") or "").strip()
     if not api_key:
-        return []
+        return [], "unavailable"
+    if "\r" in api_key or "\n" in api_key:
+        logger.warning("claude provider model discovery skipped: invalid credential format")
+        return [], "failed"
     base_url = str(
         os.environ.get("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"
     ).strip().rstrip("/")
     parsed_base = urlparse(base_url)
-    if parsed_base.scheme not in {"http", "https"} or not parsed_base.netloc:
-        logger.warning("claude provider model discovery skipped: invalid base URL")
-        return []
+    if not claude_models_api_base_url_allowed(parsed_base):
+        logger.warning("claude provider model discovery skipped: insecure or invalid base URL")
+        return [], "failed"
     endpoint = (
         f"{base_url}/models?limit=1000"
         if parsed_base.path.rstrip("/").endswith("/v1")
         else f"{base_url}/v1/models?limit=1000"
     )
-    request = urllib.request.Request(
-        endpoint,
-        headers={
-            "anthropic-version": "2023-06-01",
-            "x-api-key": api_key,
-            "accept": "application/json",
-            "user-agent": f"AgentsServer/{SERVER_VERSION}",
-        },
-        method="GET",
-    )
+    curl_bin = shutil.which("curl", path=runner_env().get("PATH"))
+    if not curl_bin:
+        logger.warning("claude provider model discovery skipped: curl unavailable")
+        return [], "unavailable"
+    timeout_seconds = max(0.5, min(RUNTIME_CATALOG_TIMEOUT_SECONDS, 6.0))
     try:
-        opener = urllib.request.build_opener(ClaudeCatalogNoRedirectHandler())
-        with opener.open(
-            request,
-            timeout=max(0.5, min(RUNTIME_CATALOG_TIMEOUT_SECONDS, 6.0)),
-        ) as response:
-            raw = response.read(CLAUDE_MODELS_API_MAX_BYTES + 1)
+        # Keep the key out of argv, the child environment, and disk by feeding
+        # curl's header-file syntax through stdin. curl's total-time limit is
+        # resistant to a peer that trickles bytes forever; subprocess.run's
+        # independent deadline kills and reaps curl if its own timer fails.
+        header_bytes = (
+            "anthropic-version: 2023-06-01\n"
+            f"x-api-key: {api_key}\n"
+            "accept: application/json\n"
+        ).encode("utf-8")
+        child_env = runner_env()
+        for secret_name in CLAUDE_PROVIDER_SECRET_ENV_NAMES:
+            child_env.pop(secret_name, None)
+        result = subprocess.run(
+            [
+                curl_bin,
+                "--fail",
+                "--silent",
+                "--show-error",
+                "--connect-timeout",
+                f"{timeout_seconds:g}",
+                "--max-time",
+                f"{timeout_seconds:g}",
+                "--max-filesize",
+                str(CLAUDE_MODELS_API_MAX_BYTES),
+                "--header",
+                "@-",
+                "--user-agent",
+                f"AgentsServer/{SERVER_VERSION}",
+                endpoint,
+            ],
+            cwd=DEFAULT_CWD if Path(DEFAULT_CWD).exists() else str(Path.home()),
+            env=child_env,
+            input=header_bytes,
+            text=False,
+            capture_output=True,
+            timeout=timeout_seconds + 1.0,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"curl exited {result.returncode}")
+        raw = result.stdout
         if len(raw) > CLAUDE_MODELS_API_MAX_BYTES:
             raise ValueError("Claude Models API response exceeds size limit")
-        return parse_claude_models_api_payload(json.loads(raw.decode("utf-8")))
+        payload = json.loads(raw.decode("utf-8"))
+        if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+            raise ValueError("Claude Models API returned an invalid payload")
+        return parse_claude_models_api_payload(payload), "success"
     except Exception as exc:
         logger.warning(
             "claude provider model discovery failed error_type=%s",
             type(exc).__name__,
         )
-        return []
+        return [], "failed"
 
 
 def claude_fallback_model_options() -> list[dict[str, Any]]:
-    options = [runtime_option(value, label) for value, label in CLAUDE_CLI_MODEL_ALIASES]
-    options.extend(
+    return [
         runtime_option(
             value,
             label,
@@ -41769,8 +41845,7 @@ def claude_fallback_model_options() -> list[dict[str, Any]]:
             *CLAUDE_CURRENT_MODEL_FALLBACKS,
             *CLAUDE_LEGACY_MODEL_FALLBACKS,
         )
-    )
-    return options
+    ]
 
 
 def parse_claude_help_catalog() -> dict[str, Any]:
@@ -41784,7 +41859,7 @@ def parse_claude_help_catalog() -> dict[str, Any]:
     )
     default_effort = os.environ.get("CLAUDE_EFFORT") or agentsdock_setting("CLAUDE_EFFORT", "")
     supports_ultracode = claude_supports_effort("ultracode")
-    provider_options = discover_claude_provider_models()
+    provider_options, provider_status = discover_claude_provider_models()
     help_text = ""
     help_available = False
     try:
@@ -41796,27 +41871,22 @@ def parse_claude_help_catalog() -> dict[str, Any]:
             type(exc).__name__,
         )
 
-    discovered_help_options = parse_claude_help_model_options(help_text)
+    discovered_help_aliases, discovered_help_full_names = (
+        parse_claude_help_model_option_groups(help_text)
+    )
     # Alias pointers remain first: unlike pinned fallback IDs, they follow a
     # new Claude release without requiring an AgentsServer update.
-    model_options.extend(
-        option
-        for option in discovered_help_options
-        if not str(option.get("value") or "").startswith("claude-")
-    )
+    model_options.extend(discovered_help_aliases)
     model_options.extend(runtime_option(value, label) for value, label in CLAUDE_CLI_MODEL_ALIASES)
-    if provider_options:
+    if provider_status == "success":
         # The API is account-scoped, so do not add pinned models that this
-        # credential did not return (notably limited-access Mythos models).
+        # credential did not return (notably limited-access Mythos models), or
+        # full-name examples from CLI help that may not be account-available.
         model_options.extend(provider_options)
     else:
         model_options.extend(claude_fallback_model_options())
-    model_options.extend(
-        option
-        for option in discovered_help_options
-        if str(option.get("value") or "").startswith("claude-")
-    )
-    if default_model and not any(
+        model_options.extend(discovered_help_full_names)
+    if provider_status != "success" and default_model and not any(
         str(option.get("value") or "") == default_model
         for option in model_options
     ):
@@ -41837,10 +41907,12 @@ def parse_claude_help_catalog() -> dict[str, Any]:
         effort_options.append(runtime_option("ultracode", "Ultracode"))
 
     model_sources = []
-    if provider_options:
+    if provider_status == "success":
         model_sources.append("Anthropic Models API")
     model_sources.append("claude --help" if help_available else "claude --help failed")
-    if not provider_options:
+    if provider_status != "success":
+        if provider_status == "failed":
+            model_sources.append("Anthropic Models API failed")
         model_sources.append("current fallback")
     effort_source = "claude --help" if help_available else "claude --help failed"
     return {

--- a/agentsdock_team_hub/store.py
+++ b/agentsdock_team_hub/store.py
@@ -265,10 +265,22 @@ class HubStore:
                     if time.monotonic() >= deadline:
                         raise RuntimeError("Team Hub local control is busy")
                     time.sleep(0.025)
-            if cls._restore_transaction_pending(root):
+            if cls._restore_recovery_pending(root):
                 attachment_lease = cls.acquire_attachment_control_lease(root)
                 try:
-                    cls._recover_interrupted_restore_unlocked(root)
+                    journal_pending = cls._restore_transaction_pending(root)
+                    protected_staging: Path | None = None
+                    if journal_pending:
+                        _journal, protected_staging, _old, _new = (
+                            cls._read_restore_transaction_journal(root)
+                        )
+                    cls._cleanup_abandoned_restore_staging_unlocked(
+                        root,
+                        protected_staging=protected_staging,
+                    )
+                    if journal_pending:
+                        cls._recover_interrupted_restore_unlocked(root)
+                    cls._cleanup_abandoned_restore_staging_unlocked(root)
                 finally:
                     cls.release_attachment_control_lease(attachment_lease)
             yield
@@ -339,7 +351,7 @@ class HubStore:
         ensure_private_directory(self.data_dir)
         # A restore swaps several independent filesystem objects. Complete or
         # roll back any durable transaction before SQLite can observe them.
-        if self._restore_transaction_pending(self.data_dir):
+        if self._restore_recovery_pending(self.data_dir):
             with self.maintenance_control_lock(self.data_dir):
                 pass
         self.team_attachment_max_bytes = _positive_int_env(
@@ -620,6 +632,64 @@ class HubStore:
         except FileNotFoundError:
             return False
         return True
+
+    @classmethod
+    def _restore_recovery_pending(cls, root: Path) -> bool:
+        if cls._restore_transaction_pending(root):
+            return True
+        try:
+            with os.scandir(root) as entries:
+                return any(
+                    RESTORE_STAGING_NAME_RE.fullmatch(entry.name) is not None
+                    for entry in entries
+                )
+        except FileNotFoundError:
+            return False
+
+    @classmethod
+    def _cleanup_abandoned_restore_staging_unlocked(
+        cls,
+        root: Path,
+        *,
+        protected_staging: Path | None = None,
+    ) -> None:
+        """Remove only validated pre-journal restore generations.
+
+        The caller owns the maintenance and attachment locks, so an exact
+        unjournaled generation cannot still be active. A valid journal's
+        staging path is excluded until commit/rollback recovery consumes it.
+        """
+
+        candidates: list[Path] = []
+        with os.scandir(root) as entries:
+            for entry in entries:
+                if RESTORE_STAGING_NAME_RE.fullmatch(entry.name) is None:
+                    continue
+                candidate = root / entry.name
+                if protected_staging is not None and candidate == protected_staging:
+                    continue
+                candidates.append(candidate)
+
+        # Validate every candidate before deleting any of them. An unsafe
+        # lookalike therefore fails closed without partially cleaning state.
+        for candidate in candidates:
+            if not cls._restore_target_exists(candidate, "directory"):
+                continue  # pragma: no cover - scandir observed the entry.
+            for directory, directory_names, file_names in os.walk(
+                candidate,
+                topdown=True,
+                followlinks=False,
+            ):
+                current = Path(directory)
+                cls._restore_target_exists(current, "directory")
+                for name in directory_names:
+                    cls._restore_target_exists(current / name, "directory")
+                for name in file_names:
+                    cls._restore_target_exists(current / name, "file")
+
+        for candidate in sorted(candidates, key=lambda path: path.name):
+            shutil.rmtree(candidate)
+            cls._fsync_directory(root)
 
     @staticmethod
     def _restore_target_kind(name: str) -> str:

--- a/agentsdock_team_hub/store.py
+++ b/agentsdock_team_hub/store.py
@@ -131,6 +131,15 @@ class _TeamAttachmentFailure(Exception):
 
 
 @dataclass(frozen=True)
+class _TeamAttachmentSnapshotFile:
+    """One file required to make attachment metadata restorable."""
+
+    relative_path: str
+    byte_size: int
+    content_sha256: str | None
+
+
+@dataclass(frozen=True)
 class AccessClaims:
     principal_id: str
     session_id: str
@@ -258,6 +267,45 @@ class HubStore:
         finally:
             with suppress(OSError):
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+
+    @classmethod
+    def acquire_attachment_control_lease(
+        cls,
+        data_dir: Path,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> int:
+        """Serialize attachment file mutation with maintenance snapshots."""
+
+        if fcntl is None:
+            raise RuntimeError("Team Hub attachment locking is unavailable")
+        root = Path(os.path.abspath(os.path.expanduser(os.fspath(data_dir))))
+        descriptor = cls._open_lock_file(root / "attachment-control.lock")
+        deadline = time.monotonic() + max(0.1, float(timeout_seconds))
+        try:
+            while True:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return descriptor
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise RuntimeError("Team Hub attachment control is busy")
+                    time.sleep(0.025)
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    @staticmethod
+    def release_attachment_control_lease(descriptor: int | None) -> None:
+        if descriptor is None:
+            return
+        if fcntl is None:
+            os.close(descriptor)
+            return
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
             os.close(descriptor)
 
     def __init__(
@@ -551,6 +599,197 @@ class HubStore:
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+
+    @classmethod
+    def _team_attachment_snapshot_files(
+        cls,
+        connection: sqlite3.Connection,
+    ) -> list[_TeamAttachmentSnapshotFile]:
+        """Derive the exact external files required by one database image."""
+
+        schema_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if schema_version < 9:
+            return []
+        try:
+            rows = connection.execute(
+                """
+                SELECT id,storage_key,sha256,state,byte_size,received_bytes
+                FROM team_attachments ORDER BY id
+                """
+            ).fetchall()
+        except sqlite3.DatabaseError as exc:
+            raise RuntimeError("Team Hub snapshot attachment schema is invalid") from exc
+        files: dict[str, _TeamAttachmentSnapshotFile] = {}
+        for row in rows:
+            attachment_id = str(row["id"])
+            storage_key = str(row["storage_key"])
+            raw_digest = row["sha256"]
+            state = str(row["state"])
+            byte_size = int(row["byte_size"])
+            received_bytes = int(row["received_bytes"])
+            if (
+                re.fullmatch(r"[A-Za-z0-9_]{8,240}", attachment_id) is None
+                or re.fullmatch(r"[0-9a-f]{64}", storage_key) is None
+                or not isinstance(raw_digest, bytes)
+                or not hmac.compare_digest(raw_digest, bytes.fromhex(storage_key))
+                or state not in {"uploading", "ready", "failed"}
+                or byte_size < 1
+                or not 0 <= received_bytes <= byte_size
+            ):
+                raise RuntimeError("Team Hub snapshot attachment metadata is invalid")
+            if state == "ready":
+                if received_bytes != byte_size:
+                    raise RuntimeError("Team Hub snapshot attachment metadata is invalid")
+                spec = _TeamAttachmentSnapshotFile(
+                    relative_path=f"{storage_key[:2]}/{storage_key}",
+                    byte_size=byte_size,
+                    content_sha256=storage_key,
+                )
+            elif state == "uploading" and received_bytes > 0:
+                spec = _TeamAttachmentSnapshotFile(
+                    relative_path=f"uploads/{attachment_id}.part",
+                    byte_size=received_bytes,
+                    content_sha256=None,
+                )
+            else:
+                continue
+            previous = files.get(spec.relative_path)
+            if previous is not None and previous != spec:
+                raise RuntimeError("Team Hub snapshot attachment metadata is invalid")
+            files[spec.relative_path] = spec
+        return [files[path] for path in sorted(files)]
+
+    @classmethod
+    def _attachment_generation_summary(
+        cls,
+        root: Path,
+        files: list[_TeamAttachmentSnapshotFile],
+        *,
+        exact_tree: bool,
+        require_root: bool,
+    ) -> dict[str, Any]:
+        """Verify one private attachment tree and return its anchored digest."""
+
+        if not root.exists():
+            if require_root or files:
+                raise RuntimeError("Team Hub snapshot attachment tree is missing")
+            return {
+                "file_count": 0,
+                "byte_size": 0,
+                "sha256": hashlib.sha256().hexdigest(),
+            }
+        try:
+            cls._validate_private_directory_without_mutation(root)
+            expected_paths = {item.relative_path for item in files}
+            expected_directories = {""}
+            for relative_path in expected_paths:
+                pieces = relative_path.split("/")
+                expected_directories.update(
+                    "/".join(pieces[:index]) for index in range(1, len(pieces))
+                )
+            if exact_tree:
+                actual_paths: set[str] = set()
+                actual_directories = {""}
+                for directory, directory_names, file_names in os.walk(
+                    root, topdown=True, followlinks=False
+                ):
+                    current = Path(directory)
+                    cls._validate_private_directory_without_mutation(current)
+                    relative_directory = current.relative_to(root).as_posix()
+                    if relative_directory == ".":
+                        relative_directory = ""
+                    for name in directory_names:
+                        child = current / name
+                        info = child.lstat()
+                        if (
+                            not stat.S_ISDIR(info.st_mode)
+                            or info.st_uid != os.getuid()
+                            or stat.S_IMODE(info.st_mode) != 0o700
+                        ):
+                            raise PermissionError(
+                                "Team Hub snapshot attachment directory is unsafe"
+                            )
+                        actual_directories.add(
+                            "/".join(part for part in (relative_directory, name) if part)
+                        )
+                    for name in file_names:
+                        relative = "/".join(
+                            part for part in (relative_directory, name) if part
+                        )
+                        actual_paths.add(relative)
+                if actual_paths != expected_paths or actual_directories != expected_directories:
+                    raise RuntimeError("Team Hub snapshot attachment tree is invalid")
+
+            digest = hashlib.sha256()
+            total_bytes = 0
+            for item in files:
+                path = root.joinpath(*item.relative_path.split("/"))
+                parent = path.parent
+                while parent != root:
+                    cls._validate_private_directory_without_mutation(parent)
+                    parent = parent.parent
+                info = path.lstat()
+                if not stat.S_ISREG(info.st_mode) or int(info.st_size) != item.byte_size:
+                    raise RuntimeError("Team Hub snapshot attachment file size is invalid")
+                file_digest = cls._sha256_private_regular_file(path)
+                if item.content_sha256 is not None and not hmac.compare_digest(
+                    file_digest, item.content_sha256
+                ):
+                    raise RuntimeError("Team Hub snapshot attachment digest is invalid")
+                record = canonical_json(
+                    {
+                        "path": item.relative_path,
+                        "byte_size": item.byte_size,
+                        "sha256": file_digest,
+                    }
+                )
+                digest.update(len(record).to_bytes(8, "big"))
+                digest.update(record)
+                total_bytes += item.byte_size
+            return {
+                "file_count": len(files),
+                "byte_size": total_bytes,
+                "sha256": digest.hexdigest(),
+            }
+        except (OSError, ValueError) as exc:
+            raise RuntimeError("Team Hub snapshot attachment tree is invalid") from exc
+
+    @classmethod
+    def _copy_attachment_generation(
+        cls,
+        source_root: Path,
+        destination_root: Path,
+        files: list[_TeamAttachmentSnapshotFile],
+    ) -> dict[str, Any]:
+        """Copy only files required by the database into a fresh private tree."""
+
+        ensure_private_directory(destination_root)
+        if files:
+            cls._validate_private_directory_without_mutation(source_root)
+        for item in files:
+            source = source_root.joinpath(*item.relative_path.split("/"))
+            source_parent = source.parent
+            while source_parent != source_root:
+                cls._validate_private_directory_without_mutation(source_parent)
+                source_parent = source_parent.parent
+            destination = destination_root.joinpath(*item.relative_path.split("/"))
+            ensure_private_directory(destination.parent)
+            cls._copy_private_regular_file(source, destination)
+        summary = cls._attachment_generation_summary(
+            destination_root,
+            files,
+            exact_tree=True,
+            require_root=True,
+        )
+        directories = sorted(
+            (path for path in destination_root.rglob("*") if path.is_dir()),
+            key=lambda path: len(path.parts),
+            reverse=True,
+        )
+        for directory in directories:
+            cls._fsync_directory(directory)
+        cls._fsync_directory(destination_root)
+        return summary
 
     def connect(self) -> sqlite3.Connection:
         return open_database(self.database_path)
@@ -988,11 +1227,11 @@ class HubStore:
         """Checkpoint and durably snapshot the bound Hub before replacement.
 
         SQLite's online backup captures the complete logical database after a
-        successful WAL checkpoint. The signing key and a manifest containing
-        only hashes and stable identities are written into the same private
-        generation; the manifest is written last and the directory rename is
-        the commit point. Existing verified generations are pruned only after
-        the new generation is complete.
+        successful WAL checkpoint. The signing key, exact attachment tree, and
+        a manifest containing only hashes and stable identities are written
+        into the same private generation; the manifest is written last and the
+        directory rename is the commit point. Existing verified generations
+        are pruned only after the new generation is complete.
         """
 
         if self.managed_host_identity is None:
@@ -1007,6 +1246,7 @@ class HubStore:
         ensure_private_directory(temporary)
         source: sqlite3.Connection | None = None
         destination: sqlite3.Connection | None = None
+        attachment_lease = self.acquire_attachment_control_lease(self.data_dir)
         try:
             source = self.connect()
             snapshot_time = _now()
@@ -1060,6 +1300,7 @@ class HubStore:
                 or str(binding[1]) != self.managed_host_identity
             ):
                 raise RuntimeError("Team Hub maintenance backup identity verification failed")
+            attachment_files = self._team_attachment_snapshot_files(destination)
             proof_rows: list[tuple[str, str, bytes]] = []
             bootstrap_claims = destination.execute(
                 """
@@ -1133,10 +1374,15 @@ class HubStore:
                             "sha256": hashlib.sha256(proof_bytes).hexdigest(),
                         }
                     )
+            attachment_summary = self._copy_attachment_generation(
+                self.data_dir / "attachments",
+                temporary / "attachments",
+                attachment_files,
+            )
             database_digest = self._sha256_private_regular_file(database_copy)
             key_digest = hashlib.sha256(key).hexdigest()
             manifest = {
-                "format": 1,
+                "format": 2,
                 "reason": clean_reason,
                 "hub_id": self.hub_id,
                 "host_server_identity": self.managed_host_identity,
@@ -1144,6 +1390,7 @@ class HubStore:
                 "database_sha256": database_digest,
                 "signing_key_sha256": key_digest,
                 "proofs": proof_manifest,
+                "attachments": attachment_summary,
                 "created_at": _iso8601(_now()),
             }
             create_secret_file(
@@ -1196,6 +1443,8 @@ class HubStore:
             if temporary.exists() and not temporary.is_symlink():
                 shutil.rmtree(temporary, ignore_errors=True)
             raise
+        finally:
+            self.release_attachment_control_lease(attachment_lease)
 
     @classmethod
     def verify_maintenance_snapshot(
@@ -1213,15 +1462,19 @@ class HubStore:
         root = Path(os.path.abspath(os.path.expanduser(os.fspath(data_dir))))
         cls._validate_private_directory_without_mutation(root)
         with cls.maintenance_control_lock(root):
-            cls._restore_maintenance_snapshot_unlocked(
-                root,
-                snapshot_dir,
-                expected_host_identity=expected_host_identity,
-                expected_hub_id=expected_hub_id,
-                expected_operation_id=expected_operation_id,
-                expected_reason=expected_reason,
-                verify_only=True,
-            )
+            attachment_lease = cls.acquire_attachment_control_lease(root)
+            try:
+                cls._restore_maintenance_snapshot_unlocked(
+                    root,
+                    snapshot_dir,
+                    expected_host_identity=expected_host_identity,
+                    expected_hub_id=expected_hub_id,
+                    expected_operation_id=expected_operation_id,
+                    expected_reason=expected_reason,
+                    verify_only=True,
+                )
+            finally:
+                cls.release_attachment_control_lease(attachment_lease)
 
     @classmethod
     def restore_maintenance_snapshot(
@@ -1237,15 +1490,19 @@ class HubStore:
         lease = cls.acquire_managed_runtime_lease(data_dir)
         try:
             with cls.maintenance_control_lock(data_dir):
-                cls._restore_maintenance_snapshot_unlocked(
-                    data_dir,
-                    snapshot_dir,
-                    expected_host_identity=expected_host_identity,
-                    expected_hub_id=expected_hub_id,
-                    expected_operation_id=expected_operation_id,
-                    expected_reason=expected_reason,
-                    verify_only=False,
-                )
+                attachment_lease = cls.acquire_attachment_control_lease(data_dir)
+                try:
+                    cls._restore_maintenance_snapshot_unlocked(
+                        data_dir,
+                        snapshot_dir,
+                        expected_host_identity=expected_host_identity,
+                        expected_hub_id=expected_hub_id,
+                        expected_operation_id=expected_operation_id,
+                        expected_reason=expected_reason,
+                        verify_only=False,
+                    )
+                finally:
+                    cls.release_attachment_control_lease(attachment_lease)
         finally:
             cls.release_managed_runtime_lease(lease)
 
@@ -1307,7 +1564,7 @@ class HubStore:
             manifest = json.loads(manifest_bytes)
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise RuntimeError("Team Hub snapshot manifest is invalid") from exc
-        required_manifest_keys = {
+        base_manifest_keys = {
             "format",
             "reason",
             "hub_id",
@@ -1318,12 +1575,20 @@ class HubStore:
             "proofs",
             "created_at",
         }
-        if not isinstance(manifest, dict) or set(manifest) != required_manifest_keys:
+        if not isinstance(manifest, dict):
+            raise RuntimeError("Team Hub snapshot manifest is invalid")
+        snapshot_format = manifest.get("format")
+        if snapshot_format == 1:
+            required_manifest_keys = base_manifest_keys
+        elif snapshot_format == 2:
+            required_manifest_keys = base_manifest_keys | {"attachments"}
+        else:
+            raise RuntimeError("Team Hub snapshot manifest is invalid")
+        if set(manifest) != required_manifest_keys:
             raise RuntimeError("Team Hub snapshot manifest is invalid")
         schema_version = manifest.get("schema_version")
         if (
-            manifest.get("format") != 1
-            or manifest.get("hub_id") != hub_id
+            manifest.get("hub_id") != hub_id
             or manifest.get("host_server_identity") != host_identity
             or manifest.get("reason") != expected_reason
             or isinstance(schema_version, bool)
@@ -1348,6 +1613,25 @@ class HubStore:
             digest = manifest.get(digest_name)
             if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
                 raise RuntimeError("Team Hub snapshot manifest digest is invalid")
+
+        attachment_manifest: dict[str, Any] | None = None
+        if snapshot_format == 2:
+            raw_attachments = manifest.get("attachments")
+            if (
+                not isinstance(raw_attachments, dict)
+                or set(raw_attachments) != {"file_count", "byte_size", "sha256"}
+                or isinstance(raw_attachments.get("file_count"), bool)
+                or not isinstance(raw_attachments.get("file_count"), int)
+                or raw_attachments["file_count"] < 0
+                or isinstance(raw_attachments.get("byte_size"), bool)
+                or not isinstance(raw_attachments.get("byte_size"), int)
+                or raw_attachments["byte_size"] < 0
+                or not isinstance(raw_attachments.get("sha256"), str)
+                or re.fullmatch(r"[0-9a-f]{64}", raw_attachments["sha256"])
+                is None
+            ):
+                raise RuntimeError("Team Hub snapshot attachment manifest is invalid")
+            attachment_manifest = raw_attachments
 
         raw_proofs = manifest.get("proofs")
         if not isinstance(raw_proofs, list) or len(raw_proofs) > 4096:
@@ -1525,14 +1809,55 @@ class HubStore:
             }
             if not active_at_snapshot.issubset(proof_entries):
                 raise RuntimeError("Team Hub snapshot omits an active local proof")
+            attachment_files = cls._team_attachment_snapshot_files(connection)
+            if snapshot_format == 2:
+                attachment_source = snapshot / "attachments"
+                attachment_summary = cls._attachment_generation_summary(
+                    attachment_source,
+                    attachment_files,
+                    exact_tree=True,
+                    require_root=True,
+                )
+                if attachment_summary != attachment_manifest:
+                    raise RuntimeError("Team Hub snapshot attachment manifest is invalid")
+            else:
+                # Format 1 predates external attachment generations. A schema-9
+                # snapshot can still be rolled back safely only while its exact
+                # content-addressed files remain in the fenced live tree. A
+                # partial upload has no digest in the legacy manifest, so it
+                # cannot be attributed to that snapshot generation safely.
+                if any(item.content_sha256 is None for item in attachment_files):
+                    raise RuntimeError(
+                        "Legacy Team Hub snapshot omits a resumable attachment generation"
+                    )
+                # New files are excluded when the staged generation is
+                # assembled below.
+                attachment_source = root / "attachments"
+                attachment_summary = cls._attachment_generation_summary(
+                    attachment_source,
+                    attachment_files,
+                    exact_tree=False,
+                    require_root=bool(attachment_files),
+                )
             connection.close()
             connection = None
 
             if verify_only:
                 return
 
+            staged_attachments = staging / "attachments"
+            staged_attachment_summary = cls._copy_attachment_generation(
+                attachment_source,
+                staged_attachments,
+                attachment_files,
+            )
+            if staged_attachment_summary != attachment_summary:
+                raise RuntimeError("Team Hub snapshot attachment generation changed")
+
             old_directory = staging / "previous"
             ensure_private_directory(old_directory)
+            failed_directory = staging / "failed"
+            ensure_private_directory(failed_directory)
             managed_targets = {
                 root / "team-hub.sqlite3",
                 root / "access-token-signing.key",
@@ -1555,6 +1880,24 @@ class HubStore:
                 os.replace(target, prior)
                 moved_old.append((prior, target))
 
+            attachment_target = root / "attachments"
+            try:
+                attachment_info = attachment_target.lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                if (
+                    not stat.S_ISDIR(attachment_info.st_mode)
+                    or attachment_info.st_uid != os.getuid()
+                    or stat.S_IMODE(attachment_info.st_mode) != 0o700
+                ):
+                    raise PermissionError(
+                        "Team Hub live attachment state contains an unsafe directory"
+                    )
+                prior = old_directory / "attachments"
+                os.replace(attachment_target, prior)
+                moved_old.append((prior, attachment_target))
+
             replacements = [
                 (staged_database, root / "team-hub.sqlite3"),
                 (staged_key, root / "access-token-signing.key"),
@@ -1563,6 +1906,7 @@ class HubStore:
                 (staged_proofs / filename, root / filename)
                 for filename in sorted(proof_entries)
             )
+            replacements.append((staged_attachments, attachment_target))
             for source, target in replacements:
                 os.replace(source, target)
                 installed.append(target)
@@ -1572,6 +1916,13 @@ class HubStore:
                 != manifest["database_sha256"]
                 or cls._sha256_private_regular_file(root / "access-token-signing.key")
                 != manifest["signing_key_sha256"]
+                or cls._attachment_generation_summary(
+                    attachment_target,
+                    attachment_files,
+                    exact_tree=True,
+                    require_root=True,
+                )
+                != attachment_summary
             ):
                 raise RuntimeError("Team Hub restored state verification failed")
         except BaseException:
@@ -1579,7 +1930,7 @@ class HubStore:
                 connection.close()
             for target in reversed(installed):
                 try:
-                    target.unlink()
+                    os.replace(target, failed_directory / target.name)
                 except FileNotFoundError:
                     pass
             for prior, target in reversed(moved_old):
@@ -7855,6 +8206,7 @@ class HubStore:
                 ]
                 if not rows:
                     raise HubError("forbidden", "This message is not addressed to the caller", 403)
+                changed_recipient_ids: list[str] = []
                 for recipient in rows:
                     current = str(recipient["state"])
                     if current == "read" or (current == "delivered" and state == "delivered"):
@@ -7876,6 +8228,7 @@ class HubStore:
                             """,
                             (timestamp, timestamp, recipient["id"]),
                         )
+                    changed_recipient_ids.append(str(recipient["id"]))
                 updated = [
                     self._team_recipient_public(recipient)
                     for recipient in self._team_message_recipients(connection, team_id, message_id)
@@ -7905,6 +8258,15 @@ class HubStore:
                     {"state": state},
                     timestamp,
                 )
+                for recipient_id in changed_recipient_ids:
+                    self._outbox(
+                        connection,
+                        team_id,
+                        "team_message_recipient",
+                        recipient_id,
+                        f"team.message.{state}",
+                        timestamp,
+                    )
                 return response
         finally:
             connection.close()
@@ -8067,6 +8429,14 @@ class HubStore:
                     {"byte_size": byte_size, "deduplicated": already_stored},
                     timestamp,
                 )
+                self._outbox(
+                    connection,
+                    team_id,
+                    "team_attachment",
+                    attachment_id,
+                    "team.attachment.declared",
+                    timestamp,
+                )
                 return response
         finally:
             connection.close()
@@ -8090,8 +8460,10 @@ class HubStore:
         if type(offset) is not int or offset < 0 or type(total) is not int or total < 1:
             raise HubError("invalid_request", "Attachment range is invalid", 422)
         timestamp = _now()
-        connection = self.connect()
+        attachment_lease = self.acquire_attachment_control_lease(self.data_dir)
+        connection: sqlite3.Connection | None = None
         try:
+            connection = self.connect()
             try:
                 return self._write_team_attachment_chunk_locked(
                     connection,
@@ -8116,7 +8488,9 @@ class HubStore:
                     )
                 raise failure.error from None
         finally:
-            connection.close()
+            if connection is not None:
+                connection.close()
+            self.release_attachment_control_lease(attachment_lease)
 
     def _write_team_attachment_chunk_locked(
         self,
@@ -8334,9 +8708,11 @@ class HubStore:
         """Remove declared uploads that never finished; never touch ready files."""
 
         timestamp = _now(now)
-        connection = self.connect()
+        attachment_lease = self.acquire_attachment_control_lease(self.data_dir)
+        connection: sqlite3.Connection | None = None
         removed = 0
         try:
+            connection = self.connect()
             with _write_transaction(connection):
                 stale = connection.execute(
                     """
@@ -8355,7 +8731,9 @@ class HubStore:
                     removed += 1
             return removed
         finally:
-            connection.close()
+            if connection is not None:
+                connection.close()
+            self.release_attachment_control_lease(attachment_lease)
 
     # -- skills -------------------------------------------------------------
 

--- a/agentsdock_team_hub/store.py
+++ b/agentsdock_team_hub/store.py
@@ -99,6 +99,8 @@ TEAM_ATTACHMENT_UPLOAD_TTL_SECONDS = 24 * 60 * 60
 MAX_TEAM_SKILLS_PER_TEAM = 500
 MAX_TEAM_SKILL_VERSIONS = 200
 MAX_TEAM_SKILL_TAGS = 8
+RESTORE_TRANSACTION_JOURNAL_NAME = ".restore-transaction.json"
+RESTORE_STAGING_NAME_RE = re.compile(r"^\.restore-[1-9][0-9]*-[0-9a-f]{16}$")
 TEAM_SKILL_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 TEAM_SKILL_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 TEAM_ATTACHMENT_FILE_NAME_RE = re.compile(r"^[^\x00-\x1f\x7f/\\]{1,255}$")
@@ -263,6 +265,12 @@ class HubStore:
                     if time.monotonic() >= deadline:
                         raise RuntimeError("Team Hub local control is busy")
                     time.sleep(0.025)
+            if cls._restore_transaction_pending(root):
+                attachment_lease = cls.acquire_attachment_control_lease(root)
+                try:
+                    cls._recover_interrupted_restore_unlocked(root)
+                finally:
+                    cls.release_attachment_control_lease(attachment_lease)
             yield
         finally:
             with suppress(OSError):
@@ -329,6 +337,11 @@ class HubStore:
             else None
         )
         ensure_private_directory(self.data_dir)
+        # A restore swaps several independent filesystem objects. Complete or
+        # roll back any durable transaction before SQLite can observe them.
+        if self._restore_transaction_pending(self.data_dir):
+            with self.maintenance_control_lock(self.data_dir):
+                pass
         self.team_attachment_max_bytes = _positive_int_env(
             "AGENTSDOCK_TEAM_ATTACHMENT_MAX_BYTES",
             DEFAULT_TEAM_ATTACHMENT_MAX_BYTES,
@@ -599,6 +612,370 @@ class HubStore:
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+
+    @staticmethod
+    def _restore_transaction_pending(root: Path) -> bool:
+        try:
+            (root / RESTORE_TRANSACTION_JOURNAL_NAME).lstat()
+        except FileNotFoundError:
+            return False
+        return True
+
+    @staticmethod
+    def _restore_target_kind(name: str) -> str:
+        if name == "attachments":
+            return "directory"
+        if name in {
+            "team-hub.sqlite3",
+            "access-token-signing.key",
+            "team-hub.sqlite3-wal",
+            "team-hub.sqlite3-shm",
+            "bootstrap-owner.proof",
+            "maintenance-fence.json",
+        } or re.fullmatch(r"[A-Za-z0-9_]{8,240}\.proof", name):
+            return "file"
+        raise RuntimeError("Team Hub restore transaction target is invalid")
+
+    @classmethod
+    def _restore_target_exists(cls, path: Path, kind: str) -> bool:
+        try:
+            info = path.lstat()
+        except FileNotFoundError:
+            return False
+        if info.st_uid != os.getuid():
+            raise PermissionError("Team Hub restore transaction target is unsafe")
+        if kind == "file":
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or info.st_nlink != 1
+                or stat.S_IMODE(info.st_mode) != 0o600
+            ):
+                raise PermissionError("Team Hub restore transaction target is unsafe")
+        elif kind == "directory":
+            if (
+                not stat.S_ISDIR(info.st_mode)
+                or stat.S_IMODE(info.st_mode) != 0o700
+            ):
+                raise PermissionError("Team Hub restore transaction target is unsafe")
+        else:  # pragma: no cover - only validated journal values reach this helper.
+            raise RuntimeError("Team Hub restore transaction target is invalid")
+        return True
+
+    @classmethod
+    def _restore_transaction_targets(
+        cls,
+        raw: Any,
+    ) -> dict[str, str]:
+        if not isinstance(raw, list) or len(raw) > 4104:
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        targets: dict[str, str] = {}
+        for entry in raw:
+            if not isinstance(entry, dict) or set(entry) != {"name", "kind"}:
+                raise RuntimeError("Team Hub restore transaction journal is invalid")
+            name = entry.get("name")
+            kind = entry.get("kind")
+            if (
+                not isinstance(name, str)
+                or not isinstance(kind, str)
+                or kind != cls._restore_target_kind(name)
+                or name in targets
+            ):
+                raise RuntimeError("Team Hub restore transaction journal is invalid")
+            targets[name] = kind
+        return targets
+
+    @classmethod
+    def _restore_transaction_generation(
+        cls,
+        raw: Any,
+        new_targets: dict[str, str],
+    ) -> dict[str, Any]:
+        if not isinstance(raw, dict) or set(raw) != {
+            "database_sha256",
+            "signing_key_sha256",
+            "proofs",
+            "attachments",
+        }:
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        for field in ("database_sha256", "signing_key_sha256"):
+            if (
+                not isinstance(raw.get(field), str)
+                or re.fullmatch(r"[0-9a-f]{64}", raw[field]) is None
+            ):
+                raise RuntimeError("Team Hub restore transaction journal is invalid")
+        raw_proofs = raw.get("proofs")
+        if not isinstance(raw_proofs, list) or len(raw_proofs) > 4096:
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        proof_names = {
+            name
+            for name in new_targets
+            if name == "bootstrap-owner.proof"
+            or re.fullmatch(r"[A-Za-z0-9_]{8,240}\.proof", name)
+        }
+        proof_digests: dict[str, str] = {}
+        for entry in raw_proofs:
+            if not isinstance(entry, dict) or set(entry) != {"name", "sha256"}:
+                raise RuntimeError("Team Hub restore transaction journal is invalid")
+            name = entry.get("name")
+            digest = entry.get("sha256")
+            if (
+                not isinstance(name, str)
+                or name not in proof_names
+                or name in proof_digests
+                or not isinstance(digest, str)
+                or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            ):
+                raise RuntimeError("Team Hub restore transaction journal is invalid")
+            proof_digests[name] = digest
+        if proof_digests.keys() != proof_names:
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        attachments = raw.get("attachments")
+        if (
+            not isinstance(attachments, dict)
+            or set(attachments) != {"file_count", "byte_size", "sha256"}
+            or isinstance(attachments.get("file_count"), bool)
+            or not isinstance(attachments.get("file_count"), int)
+            or attachments["file_count"] < 0
+            or isinstance(attachments.get("byte_size"), bool)
+            or not isinstance(attachments.get("byte_size"), int)
+            or attachments["byte_size"] < 0
+            or not isinstance(attachments.get("sha256"), str)
+            or re.fullmatch(r"[0-9a-f]{64}", attachments["sha256"]) is None
+        ):
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        return raw
+
+    @classmethod
+    def _read_restore_transaction_journal(
+        cls,
+        root: Path,
+    ) -> tuple[dict[str, Any], Path, dict[str, str], dict[str, str]]:
+        raw = cls._read_private_regular_file(
+            root / RESTORE_TRANSACTION_JOURNAL_NAME,
+            maximum_bytes=512 * 1024,
+        )
+        try:
+            journal = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("Team Hub restore transaction journal is invalid") from exc
+        if (
+            not isinstance(journal, dict)
+            or set(journal)
+            != {
+                "format",
+                "state",
+                "staging",
+                "old_targets",
+                "new_targets",
+                "new_generation",
+            }
+            or journal.get("format") != 1
+            or journal.get("state") not in {"prepared", "committed"}
+            or not isinstance(journal.get("staging"), str)
+            or RESTORE_STAGING_NAME_RE.fullmatch(journal["staging"]) is None
+        ):
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        old_targets = cls._restore_transaction_targets(journal["old_targets"])
+        new_targets = cls._restore_transaction_targets(journal["new_targets"])
+        if (
+            not {"team-hub.sqlite3", "access-token-signing.key", "maintenance-fence.json"}
+            .issubset(old_targets)
+            or not {"team-hub.sqlite3", "access-token-signing.key", "attachments"}
+            .issubset(new_targets)
+            or {"team-hub.sqlite3-wal", "team-hub.sqlite3-shm", "maintenance-fence.json"}
+            & new_targets.keys()
+        ):
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        cls._restore_transaction_generation(journal["new_generation"], new_targets)
+        staging = root / journal["staging"]
+        if staging.parent != root:
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        return journal, staging, old_targets, new_targets
+
+    @classmethod
+    def _write_restore_transaction_journal(
+        cls,
+        root: Path,
+        journal: dict[str, Any],
+    ) -> None:
+        # Validate the exact record before making it the recovery authority.
+        old_targets = cls._restore_transaction_targets(journal.get("old_targets"))
+        new_targets = cls._restore_transaction_targets(journal.get("new_targets"))
+        if (
+            set(journal)
+            != {
+                "format",
+                "state",
+                "staging",
+                "old_targets",
+                "new_targets",
+                "new_generation",
+            }
+            or journal.get("format") != 1
+            or journal.get("state") not in {"prepared", "committed"}
+            or not isinstance(journal.get("staging"), str)
+            or RESTORE_STAGING_NAME_RE.fullmatch(journal["staging"]) is None
+            or not {"team-hub.sqlite3", "access-token-signing.key", "maintenance-fence.json"}
+            .issubset(old_targets)
+            or not {"team-hub.sqlite3", "access-token-signing.key", "attachments"}
+            .issubset(new_targets)
+            or {"team-hub.sqlite3-wal", "team-hub.sqlite3-shm", "maintenance-fence.json"}
+            & new_targets.keys()
+            or len(old_targets) > 4104
+        ):
+            raise RuntimeError("Team Hub restore transaction journal is invalid")
+        cls._restore_transaction_generation(journal.get("new_generation"), new_targets)
+        payload = canonical_json(journal) + b"\n"
+        temporary = root / (
+            ".restore-transaction.tmp-"
+            f"{os.getpid()}-{secrets.token_hex(8)}"
+        )
+        descriptor = -1
+        try:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(temporary, flags, 0o600)
+            offset = 0
+            while offset < len(payload):
+                offset += os.write(descriptor, payload[offset:])
+            os.fchmod(descriptor, 0o600)
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            os.replace(temporary, root / RESTORE_TRANSACTION_JOURNAL_NAME)
+            cls._fsync_directory(root)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            with suppress(FileNotFoundError):
+                temporary.unlink()
+
+    @classmethod
+    def _recover_interrupted_restore_unlocked(cls, root: Path) -> None:
+        """Resolve one durable restore transaction before SQLite opens.
+
+        A prepared transaction always rolls back. A committed transaction has
+        already fsynced and verified the complete replacement generation, so
+        recovery keeps it and only finishes cleanup. Every recovery rename is
+        itself replay-safe if the process is interrupted again.
+        """
+
+        journal, staging, old_targets, new_targets = (
+            cls._read_restore_transaction_journal(root)
+        )
+        staging_exists = cls._restore_target_exists(staging, "directory")
+        if journal["state"] == "prepared":
+            previous = staging / "previous"
+            previous_exists = False
+            if staging_exists:
+                previous_exists = cls._restore_target_exists(previous, "directory")
+            if previous_exists:
+                discarded = staging / "recovery-discarded"
+                ensure_private_directory(discarded)
+                cls._fsync_directory(staging)
+                for name in sorted(old_targets.keys() | new_targets.keys()):
+                    kind = old_targets.get(name, new_targets.get(name))
+                    assert kind is not None
+                    target = root / name
+                    prior = previous / name
+                    prior_exists = cls._restore_target_exists(prior, kind)
+                    target_exists = cls._restore_target_exists(target, kind)
+                    if name in old_targets:
+                        if prior_exists:
+                            if target_exists:
+                                discard = discarded / f"{name}-{secrets.token_hex(8)}"
+                                os.replace(target, discard)
+                                cls._fsync_directory(root)
+                                cls._fsync_directory(discarded)
+                            os.replace(prior, target)
+                            cls._fsync_directory(previous)
+                            cls._fsync_directory(root)
+                        elif not target_exists:
+                            raise RuntimeError(
+                                "Team Hub restore transaction cannot recover old state"
+                            )
+                    else:
+                        if prior_exists:
+                            raise RuntimeError(
+                                "Team Hub restore transaction journal is inconsistent"
+                            )
+                        if target_exists:
+                            discard = discarded / f"{name}-{secrets.token_hex(8)}"
+                            os.replace(target, discard)
+                            cls._fsync_directory(root)
+                            cls._fsync_directory(discarded)
+
+            for name, kind in old_targets.items():
+                if not cls._restore_target_exists(root / name, kind):
+                    raise RuntimeError(
+                        "Team Hub restore transaction cannot recover old state"
+                    )
+            for name, kind in new_targets.items():
+                if name not in old_targets and cls._restore_target_exists(root / name, kind):
+                    raise RuntimeError(
+                        "Team Hub restore transaction rollback is incomplete"
+                    )
+        else:
+            for name, kind in new_targets.items():
+                if not cls._restore_target_exists(root / name, kind):
+                    raise RuntimeError(
+                        "Team Hub committed restore transaction is incomplete"
+                    )
+            for name, kind in old_targets.items():
+                if name not in new_targets and cls._restore_target_exists(root / name, kind):
+                    raise RuntimeError(
+                        "Team Hub committed restore transaction is inconsistent"
+                    )
+            generation = cls._restore_transaction_generation(
+                journal["new_generation"], new_targets
+            )
+            if (
+                not hmac.compare_digest(
+                    cls._sha256_private_regular_file(root / "team-hub.sqlite3"),
+                    generation["database_sha256"],
+                )
+                or not hmac.compare_digest(
+                    cls._sha256_private_regular_file(root / "access-token-signing.key"),
+                    generation["signing_key_sha256"],
+                )
+            ):
+                raise RuntimeError(
+                    "Team Hub committed restore transaction generation is invalid"
+                )
+            for proof in generation["proofs"]:
+                if not hmac.compare_digest(
+                    cls._sha256_private_regular_file(root / proof["name"]),
+                    proof["sha256"],
+                ):
+                    raise RuntimeError(
+                        "Team Hub committed restore transaction generation is invalid"
+                    )
+            connection = sqlite3.connect(
+                f"file:{root / 'team-hub.sqlite3'}?mode=ro&immutable=1",
+                uri=True,
+                isolation_level=None,
+            )
+            connection.row_factory = sqlite3.Row
+            try:
+                attachment_files = cls._team_attachment_snapshot_files(connection)
+            finally:
+                connection.close()
+            if cls._attachment_generation_summary(
+                root / "attachments",
+                attachment_files,
+                exact_tree=True,
+                require_root=True,
+            ) != generation["attachments"]:
+                raise RuntimeError(
+                    "Team Hub committed restore transaction generation is invalid"
+                )
+
+        if staging_exists:
+            shutil.rmtree(staging)
+            cls._fsync_directory(root)
+        journal_path = root / RESTORE_TRANSACTION_JOURNAL_NAME
+        journal_path.unlink()
+        cls._fsync_directory(root)
 
     @classmethod
     def _team_attachment_snapshot_files(
@@ -1666,8 +2043,6 @@ class HubStore:
         else:
             staging = root / f".restore-{os.getpid()}-{secrets.token_hex(8)}"
             ensure_private_directory(staging)
-        installed: list[Path] = []
-        moved_old: list[tuple[Path, Path]] = []
         connection: sqlite3.Connection | None = None
         try:
             staged_database = staging / "team-hub.sqlite3"
@@ -1856,8 +2231,6 @@ class HubStore:
 
             old_directory = staging / "previous"
             ensure_private_directory(old_directory)
-            failed_directory = staging / "failed"
-            ensure_private_directory(failed_directory)
             managed_targets = {
                 root / "team-hub.sqlite3",
                 root / "access-token-signing.key",
@@ -1869,35 +2242,7 @@ class HubStore:
             for entry in root.glob("*.proof"):
                 if re.fullmatch(r"[A-Za-z0-9_]{8,240}\.proof", entry.name):
                     managed_targets.add(entry)
-            for target in sorted(managed_targets, key=lambda item: item.name):
-                try:
-                    info = target.lstat()
-                except FileNotFoundError:
-                    continue
-                if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or info.st_uid != os.getuid():
-                    raise PermissionError("Team Hub live state contains an unsafe file")
-                prior = old_directory / target.name
-                os.replace(target, prior)
-                moved_old.append((prior, target))
-
             attachment_target = root / "attachments"
-            try:
-                attachment_info = attachment_target.lstat()
-            except FileNotFoundError:
-                pass
-            else:
-                if (
-                    not stat.S_ISDIR(attachment_info.st_mode)
-                    or attachment_info.st_uid != os.getuid()
-                    or stat.S_IMODE(attachment_info.st_mode) != 0o700
-                ):
-                    raise PermissionError(
-                        "Team Hub live attachment state contains an unsafe directory"
-                    )
-                prior = old_directory / "attachments"
-                os.replace(attachment_target, prior)
-                moved_old.append((prior, attachment_target))
-
             replacements = [
                 (staged_database, root / "team-hub.sqlite3"),
                 (staged_key, root / "access-token-signing.key"),
@@ -1907,9 +2252,57 @@ class HubStore:
                 for filename in sorted(proof_entries)
             )
             replacements.append((staged_attachments, attachment_target))
+
+            old_targets: dict[str, str] = {}
+            for target in sorted(managed_targets, key=lambda item: item.name):
+                kind = cls._restore_target_kind(target.name)
+                if cls._restore_target_exists(target, kind):
+                    old_targets[target.name] = kind
+            if cls._restore_target_exists(attachment_target, "directory"):
+                old_targets[attachment_target.name] = "directory"
+            new_targets = {
+                target.name: cls._restore_target_kind(target.name)
+                for _source, target in replacements
+            }
+            for source, target in replacements:
+                if not cls._restore_target_exists(source, new_targets[target.name]):
+                    raise RuntimeError("Team Hub staged restore generation is incomplete")
+
+            if proof_entries:
+                cls._fsync_directory(staged_proofs)
+            cls._fsync_directory(old_directory)
+            cls._fsync_directory(staging)
+            journal = {
+                "format": 1,
+                "state": "prepared",
+                "staging": staging.name,
+                "old_targets": [
+                    {"name": name, "kind": old_targets[name]}
+                    for name in sorted(old_targets)
+                ],
+                "new_targets": [
+                    {"name": name, "kind": new_targets[name]}
+                    for name in sorted(new_targets)
+                ],
+                "new_generation": {
+                    "database_sha256": manifest["database_sha256"],
+                    "signing_key_sha256": manifest["signing_key_sha256"],
+                    "proofs": [
+                        {"name": filename, "sha256": proof_entries[filename][1]}
+                        for filename in sorted(proof_entries)
+                    ],
+                    "attachments": attachment_summary,
+                },
+            }
+            cls._write_restore_transaction_journal(root, journal)
+
+            for name in sorted(old_targets):
+                os.replace(root / name, old_directory / name)
+            cls._fsync_directory(old_directory)
+            cls._fsync_directory(root)
             for source, target in replacements:
                 os.replace(source, target)
-                installed.append(target)
+            cls._fsync_directory(staging)
             cls._fsync_directory(root)
             if (
                 cls._sha256_private_regular_file(root / "team-hub.sqlite3")
@@ -1925,25 +2318,39 @@ class HubStore:
                 != attachment_summary
             ):
                 raise RuntimeError("Team Hub restored state verification failed")
+            committed_journal = dict(journal)
+            committed_journal["state"] = "committed"
+            cls._write_restore_transaction_journal(root, committed_journal)
+            cls._recover_interrupted_restore_unlocked(root)
         except BaseException:
             if connection is not None:
                 connection.close()
-            for target in reversed(installed):
+            recovered_committed = False
+            if not verify_only and cls._restore_transaction_pending(root):
                 try:
-                    os.replace(target, failed_directory / target.name)
-                except FileNotFoundError:
-                    pass
-            for prior, target in reversed(moved_old):
-                if prior.exists():
-                    os.replace(prior, target)
-            with suppress(OSError):
-                cls._fsync_directory(root)
+                    pending_journal, _staging, _old, _new = (
+                        cls._read_restore_transaction_journal(root)
+                    )
+                    recovered_committed = pending_journal["state"] == "committed"
+                    cls._recover_interrupted_restore_unlocked(root)
+                except BaseException as recovery_error:
+                    raise RuntimeError(
+                        "Team Hub interrupted restore recovery failed"
+                    ) from recovery_error
+            if recovered_committed:
+                return
             raise
         finally:
             if verification_directory is not None:
                 verification_directory.cleanup()
-            elif staging.exists() and not staging.is_symlink():
-                shutil.rmtree(staging, ignore_errors=True)
+            elif not cls._restore_transaction_pending(root):
+                try:
+                    staging_info = staging.lstat()
+                except FileNotFoundError:
+                    pass
+                else:
+                    if stat.S_ISDIR(staging_info.st_mode):
+                        shutil.rmtree(staging, ignore_errors=True)
 
     def renew_bootstrap_proof(self) -> Path:
         timestamp = _now()

--- a/test_runtime_diagnostics.py
+++ b/test_runtime_diagnostics.py
@@ -656,7 +656,7 @@ class RuntimeDiagnosticTests(unittest.TestCase):
 """
         with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
             agent_server, "claude_supports_effort", return_value=False
-        ):
+        ), patch.object(agent_server, "discover_claude_provider_models", return_value=[]):
             catalog = agent_server.parse_claude_help_catalog()
         self.assertEqual(
             [option["value"] for option in catalog["efforts"]],
@@ -670,12 +670,135 @@ class RuntimeDiagnosticTests(unittest.TestCase):
 """
         with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
             agent_server, "claude_supports_effort", return_value=True
-        ):
+        ), patch.object(agent_server, "discover_claude_provider_models", return_value=[]):
             catalog = agent_server.parse_claude_help_catalog()
         self.assertEqual(
             [option["value"] for option in catalog["efforts"]],
             ["", "low", "medium", "high", "xhigh", "max", "ultracode"],
         )
+
+    def test_claude_help_model_parser_keeps_aliases_and_full_name_example(self) -> None:
+        help_text = """\
+  --model <model>                       Provide an alias for the latest model
+                                        (e.g. 'fable', 'opus', or 'sonnet') or
+                                        a model's full name (e.g.
+                                        'claude-fable-5-1').
+  -n, --name <name>                     Set a display name
+"""
+        self.assertEqual(
+            [
+                option["value"]
+                for option in agent_server.parse_claude_help_model_options(help_text)
+            ],
+            ["fable", "opus", "sonnet", "claude-fable-5-1"],
+        )
+
+    def test_claude_catalog_fallback_includes_current_official_models(self) -> None:
+        help_text = """\
+  --model <model>                       Provide an alias for the latest model
+                                        (e.g. 'fable', 'opus', or 'sonnet')
+"""
+        with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
+            agent_server, "claude_supports_effort", return_value=False
+        ), patch.object(agent_server, "discover_claude_provider_models", return_value=[]):
+            catalog = agent_server.parse_claude_help_catalog()
+
+        by_value = {option["value"]: option for option in catalog["models"]}
+        self.assertIn("fable", by_value)
+        self.assertIn("opus", by_value)
+        self.assertIn("sonnet", by_value)
+        self.assertEqual(by_value["claude-fable-5-1"]["label"], "Fable 5.1")
+        self.assertEqual(by_value["claude-mythos-5-1"]["availability"], "limited")
+        self.assertIn("claude-opus-5", by_value)
+        self.assertIn("claude-sonnet-5", by_value)
+        self.assertIn("current fallback", catalog["model_source"])
+
+    def test_claude_catalog_uses_account_scoped_models_without_extra_pins(self) -> None:
+        provider_options = [
+            agent_server.runtime_option("claude-account-model-7", "Account Model 7")
+        ]
+        help_text = """\
+  --model <model>                       Provide an alias for the latest model
+                                        (e.g. 'fable', 'opus', or 'sonnet')
+"""
+        with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
+            agent_server, "claude_supports_effort", return_value=False
+        ), patch.object(
+            agent_server,
+            "discover_claude_provider_models",
+            return_value=provider_options,
+        ):
+            catalog = agent_server.parse_claude_help_catalog()
+
+        values = [option["value"] for option in catalog["models"]]
+        self.assertIn("fable", values)
+        self.assertIn("claude-account-model-7", values)
+        self.assertNotIn("claude-fable-5-1", values)
+        self.assertIn("Anthropic Models API", catalog["model_source"])
+        self.assertNotIn("current fallback", catalog["model_source"])
+
+    def test_claude_models_api_discovery_is_account_scoped_and_bounded(self) -> None:
+        payload = json.dumps({
+            "data": [
+                {"id": "claude-fable-5-1", "display_name": "Claude Fable 5.1"},
+                {"id": "not valid whitespace", "display_name": "Invalid"},
+            ]
+        }).encode("utf-8")
+        captured: dict[str, object] = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def read(self, size: int) -> bytes:
+                captured["read_size"] = size
+                return payload
+
+        class Opener:
+            def open(self, request, timeout: float):
+                captured["request"] = request
+                captured["timeout"] = timeout
+                return Response()
+
+        with patch.dict(
+            agent_server.os.environ,
+            {
+                "ANTHROPIC_API_KEY": "test-secret-never-log",
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+            },
+        ), patch.object(
+            agent_server.urllib.request,
+            "build_opener",
+            return_value=Opener(),
+        ) as build_opener:
+            options = agent_server.discover_claude_provider_models()
+
+        self.assertEqual(
+            options,
+            [{"value": "claude-fable-5-1", "label": "Claude Fable 5.1"}],
+        )
+        request = captured["request"]
+        self.assertEqual(request.full_url, "https://api.anthropic.com/v1/models?limit=1000")
+        self.assertEqual(request.get_header("X-api-key"), "test-secret-never-log")
+        self.assertEqual(
+            captured["read_size"],
+            agent_server.CLAUDE_MODELS_API_MAX_BYTES + 1,
+        )
+        self.assertIsInstance(
+            build_opener.call_args.args[0],
+            agent_server.ClaudeCatalogNoRedirectHandler,
+        )
+
+    def test_claude_models_api_is_not_contacted_without_api_key(self) -> None:
+        with patch.dict(agent_server.os.environ, {"ANTHROPIC_API_KEY": ""}), patch.object(
+            agent_server.urllib.request,
+            "build_opener",
+        ) as build_opener:
+            self.assertEqual(agent_server.discover_claude_provider_models(), [])
+        build_opener.assert_not_called()
 
     def test_claude_effort_probe_rejects_unknown_values(self) -> None:
         warning = "Warning: Unknown --effort value 'ultracode' - ignoring it and using the default effort."

--- a/test_runtime_diagnostics.py
+++ b/test_runtime_diagnostics.py
@@ -656,7 +656,11 @@ class RuntimeDiagnosticTests(unittest.TestCase):
 """
         with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
             agent_server, "claude_supports_effort", return_value=False
-        ), patch.object(agent_server, "discover_claude_provider_models", return_value=[]):
+        ), patch.object(
+            agent_server,
+            "discover_claude_provider_models",
+            return_value=([], "unavailable"),
+        ):
             catalog = agent_server.parse_claude_help_catalog()
         self.assertEqual(
             [option["value"] for option in catalog["efforts"]],
@@ -670,7 +674,11 @@ class RuntimeDiagnosticTests(unittest.TestCase):
 """
         with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
             agent_server, "claude_supports_effort", return_value=True
-        ), patch.object(agent_server, "discover_claude_provider_models", return_value=[]):
+        ), patch.object(
+            agent_server,
+            "discover_claude_provider_models",
+            return_value=([], "unavailable"),
+        ):
             catalog = agent_server.parse_claude_help_catalog()
         self.assertEqual(
             [option["value"] for option in catalog["efforts"]],
@@ -700,7 +708,11 @@ class RuntimeDiagnosticTests(unittest.TestCase):
 """
         with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
             agent_server, "claude_supports_effort", return_value=False
-        ), patch.object(agent_server, "discover_claude_provider_models", return_value=[]):
+        ), patch.object(
+            agent_server,
+            "discover_claude_provider_models",
+            return_value=([], "unavailable"),
+        ):
             catalog = agent_server.parse_claude_help_catalog()
 
         by_value = {option["value"]: option for option in catalog["models"]}
@@ -719,14 +731,17 @@ class RuntimeDiagnosticTests(unittest.TestCase):
         ]
         help_text = """\
   --model <model>                       Provide an alias for the latest model
-                                        (e.g. 'fable', 'opus', or 'sonnet')
+                                        (e.g. 'fable', 'opus', or 'sonnet') or
+                                        a model's full name (e.g.
+                                        'claude-fable-5' or
+                                        'anthropic.claude-fable-5')
 """
         with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
             agent_server, "claude_supports_effort", return_value=False
         ), patch.object(
             agent_server,
             "discover_claude_provider_models",
-            return_value=provider_options,
+            return_value=(provider_options, "success"),
         ):
             catalog = agent_server.parse_claude_help_catalog()
 
@@ -734,6 +749,34 @@ class RuntimeDiagnosticTests(unittest.TestCase):
         self.assertIn("fable", values)
         self.assertIn("claude-account-model-7", values)
         self.assertNotIn("claude-fable-5-1", values)
+        self.assertNotIn("claude-fable-5", values)
+        self.assertNotIn("anthropic.claude-fable-5", values)
+        self.assertNotIn("claude-opus-4-8[1m]", values)
+        self.assertIn("Anthropic Models API", catalog["model_source"])
+        self.assertNotIn("current fallback", catalog["model_source"])
+
+    def test_claude_catalog_treats_successful_empty_provider_list_as_authoritative(self) -> None:
+        help_text = """\
+  --model <model>                       Provide an alias for the latest model
+                                        (e.g. 'fable', 'opus', or 'sonnet') or
+                                        a full name (e.g. 'claude-fable-5')
+"""
+        with patch.object(agent_server, "run_catalog_command", return_value=help_text), patch.object(
+            agent_server, "claude_supports_effort", return_value=False
+        ), patch.object(
+            agent_server,
+            "discover_claude_provider_models",
+            return_value=([], "success"),
+        ):
+            catalog = agent_server.parse_claude_help_catalog()
+
+        values = [option["value"] for option in catalog["models"]]
+        self.assertIn("fable", values)
+        self.assertIn("opus", values)
+        self.assertIn("sonnet", values)
+        self.assertNotIn("claude-fable-5", values)
+        self.assertNotIn("claude-fable-5-1", values)
+        self.assertNotIn("claude-opus-4-8[1m]", values)
         self.assertIn("Anthropic Models API", catalog["model_source"])
         self.assertNotIn("current fallback", catalog["model_source"])
 
@@ -746,22 +789,16 @@ class RuntimeDiagnosticTests(unittest.TestCase):
         }).encode("utf-8")
         captured: dict[str, object] = {}
 
-        class Response:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return None
-
-            def read(self, size: int) -> bytes:
-                captured["read_size"] = size
-                return payload
-
-        class Opener:
-            def open(self, request, timeout: float):
-                captured["request"] = request
-                captured["timeout"] = timeout
-                return Response()
+        def run_curl(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            captured["headers"] = kwargs["input"].decode("utf-8")
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=payload,
+                stderr=b"",
+            )
 
         with patch.dict(
             agent_server.os.environ,
@@ -770,35 +807,120 @@ class RuntimeDiagnosticTests(unittest.TestCase):
                 "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
             },
         ), patch.object(
-            agent_server.urllib.request,
-            "build_opener",
-            return_value=Opener(),
-        ) as build_opener:
-            options = agent_server.discover_claude_provider_models()
+            agent_server.shutil,
+            "which",
+            return_value="/usr/bin/curl",
+        ), patch.object(
+            agent_server.subprocess,
+            "run",
+            side_effect=run_curl,
+        ):
+            options, status = agent_server.discover_claude_provider_models()
 
+        self.assertEqual(status, "success")
         self.assertEqual(
             options,
             [{"value": "claude-fable-5-1", "label": "Claude Fable 5.1"}],
         )
-        request = captured["request"]
-        self.assertEqual(request.full_url, "https://api.anthropic.com/v1/models?limit=1000")
-        self.assertEqual(request.get_header("X-api-key"), "test-secret-never-log")
-        self.assertEqual(
-            captured["read_size"],
-            agent_server.CLAUDE_MODELS_API_MAX_BYTES + 1,
-        )
-        self.assertIsInstance(
-            build_opener.call_args.args[0],
-            agent_server.ClaudeCatalogNoRedirectHandler,
-        )
+        args = captured["args"]
+        kwargs = captured["kwargs"]
+        self.assertEqual(args[-1], "https://api.anthropic.com/v1/models?limit=1000")
+        self.assertIn("--max-time", args)
+        self.assertIn("--max-filesize", args)
+        self.assertEqual(args[args.index("--header") + 1], "@-")
+        self.assertNotIn("test-secret-never-log", " ".join(args))
+        self.assertIn("x-api-key: test-secret-never-log", captured["headers"])
+        for secret_name in agent_server.CLAUDE_PROVIDER_SECRET_ENV_NAMES:
+            self.assertNotIn(secret_name, kwargs["env"])
+        self.assertLessEqual(kwargs["timeout"], 7.0)
 
     def test_claude_models_api_is_not_contacted_without_api_key(self) -> None:
         with patch.dict(agent_server.os.environ, {"ANTHROPIC_API_KEY": ""}), patch.object(
-            agent_server.urllib.request,
-            "build_opener",
-        ) as build_opener:
-            self.assertEqual(agent_server.discover_claude_provider_models(), [])
-        build_opener.assert_not_called()
+            agent_server.shutil,
+            "which",
+        ) as which:
+            self.assertEqual(
+                agent_server.discover_claude_provider_models(),
+                ([], "unavailable"),
+            )
+        which.assert_not_called()
+
+    def test_claude_models_api_rejects_non_loopback_plain_http(self) -> None:
+        with patch.dict(
+            agent_server.os.environ,
+            {
+                "ANTHROPIC_API_KEY": "test-secret-never-log",
+                "ANTHROPIC_BASE_URL": "http://models.example.test",
+            },
+        ), patch.object(agent_server.shutil, "which") as which, patch.object(
+            agent_server.subprocess,
+            "run",
+        ) as run:
+            self.assertEqual(
+                agent_server.discover_claude_provider_models(),
+                ([], "failed"),
+            )
+        which.assert_not_called()
+        run.assert_not_called()
+
+    def test_claude_models_api_allows_loopback_plain_http(self) -> None:
+        result = subprocess.CompletedProcess(
+            args=["curl"],
+            returncode=0,
+            stdout=b'{"data": []}',
+            stderr=b"",
+        )
+        with patch.dict(
+            agent_server.os.environ,
+            {
+                "ANTHROPIC_API_KEY": "test-secret-never-log",
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:8099/v1",
+            },
+        ), patch.object(
+            agent_server.shutil,
+            "which",
+            return_value="/usr/bin/curl",
+        ), patch.object(
+            agent_server.subprocess,
+            "run",
+            return_value=result,
+        ) as run:
+            self.assertEqual(
+                agent_server.discover_claude_provider_models(),
+                ([], "success"),
+            )
+        self.assertEqual(
+            run.call_args.args[0][-1],
+            "http://127.0.0.1:8099/v1/models?limit=1000",
+        )
+
+    def test_claude_models_api_trickle_has_hard_process_deadline(self) -> None:
+        with patch.dict(
+            agent_server.os.environ,
+            {
+                "ANTHROPIC_API_KEY": "test-secret-never-log",
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+            },
+        ), patch.object(
+            agent_server.shutil,
+            "which",
+            return_value="/usr/bin/curl",
+        ), patch.object(
+            agent_server.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("curl", 7),
+        ) as run:
+            self.assertEqual(
+                agent_server.discover_claude_provider_models(),
+                ([], "failed"),
+            )
+
+        args = run.call_args.args[0]
+        kwargs = run.call_args.kwargs
+        self.assertIn("--max-time", args)
+        self.assertLessEqual(float(args[args.index("--max-time") + 1]), 6.0)
+        self.assertLessEqual(kwargs["timeout"], 7.0)
+        self.assertNotIn("test-secret-never-log", " ".join(args))
 
     def test_claude_effort_probe_rejects_unknown_values(self) -> None:
         warning = "Warning: Unknown --effort value 'ultracode' - ignoring it and using the default effort."

--- a/test_runtime_diagnostics.py
+++ b/test_runtime_diagnostics.py
@@ -824,7 +824,9 @@ class RuntimeDiagnosticTests(unittest.TestCase):
         )
         args = captured["args"]
         kwargs = captured["kwargs"]
+        self.assertEqual(args[1], "--disable")
         self.assertEqual(args[-1], "https://api.anthropic.com/v1/models?limit=1000")
+        self.assertNotIn("--noproxy", args)
         self.assertIn("--max-time", args)
         self.assertIn("--max-filesize", args)
         self.assertEqual(args[args.index("--header") + 1], "@-")
@@ -875,6 +877,8 @@ class RuntimeDiagnosticTests(unittest.TestCase):
             {
                 "ANTHROPIC_API_KEY": "test-secret-never-log",
                 "ANTHROPIC_BASE_URL": "http://127.0.0.1:8099/v1",
+                "ALL_PROXY": "http://proxy.example.test:8080",
+                "HTTP_PROXY": "http://proxy.example.test:8080",
             },
         ), patch.object(
             agent_server.shutil,
@@ -893,6 +897,9 @@ class RuntimeDiagnosticTests(unittest.TestCase):
             run.call_args.args[0][-1],
             "http://127.0.0.1:8099/v1/models?limit=1000",
         )
+        args = run.call_args.args[0]
+        self.assertEqual(args[1], "--disable")
+        self.assertEqual(args[args.index("--noproxy") + 1], "*")
 
     def test_claude_models_api_trickle_has_hard_process_deadline(self) -> None:
         with patch.dict(

--- a/test_team_hub_host.py
+++ b/test_team_hub_host.py
@@ -855,7 +855,7 @@ class VendoredTeamHubParityTests(unittest.TestCase):
             "secure_peer.py": "f5f666b78527220c20462a7abdc6552aa217100b02818080756b52ad7a0de2fa",
             "secure_peer_hub.py": "d63748388ec20d8c7e11fa3ba77d6d207cc18cee0658c54d05e9e99701c41eda",
             "service.py": "c5b2e58f519cc4f23b0f4823a10f24cedbdafd46c8e6a0dd1c3728d3dbf009c0",
-            "store.py": "a43ef9e782fdc6327736018e51b2b9cf94fdb2d0f28a19303b8436d086dd84c9",
+            "store.py": "44cfea5c06c2a002f8b00d527118aab4368b0cc7766cec025ed2365f1e641580",
         }
         entries = list(vendored.rglob("*"))
         for path in entries:

--- a/test_team_hub_host.py
+++ b/test_team_hub_host.py
@@ -855,7 +855,7 @@ class VendoredTeamHubParityTests(unittest.TestCase):
             "secure_peer.py": "f5f666b78527220c20462a7abdc6552aa217100b02818080756b52ad7a0de2fa",
             "secure_peer_hub.py": "d63748388ec20d8c7e11fa3ba77d6d207cc18cee0658c54d05e9e99701c41eda",
             "service.py": "c5b2e58f519cc4f23b0f4823a10f24cedbdafd46c8e6a0dd1c3728d3dbf009c0",
-            "store.py": "3a76a0f88328da2e0880e68383dc537bbea71d1cc513bcec1964373350c25f20",
+            "store.py": "a43ef9e782fdc6327736018e51b2b9cf94fdb2d0f28a19303b8436d086dd84c9",
         }
         entries = list(vendored.rglob("*"))
         for path in entries:

--- a/test_team_hub_host.py
+++ b/test_team_hub_host.py
@@ -855,7 +855,7 @@ class VendoredTeamHubParityTests(unittest.TestCase):
             "secure_peer.py": "f5f666b78527220c20462a7abdc6552aa217100b02818080756b52ad7a0de2fa",
             "secure_peer_hub.py": "d63748388ec20d8c7e11fa3ba77d6d207cc18cee0658c54d05e9e99701c41eda",
             "service.py": "c5b2e58f519cc4f23b0f4823a10f24cedbdafd46c8e6a0dd1c3728d3dbf009c0",
-            "store.py": "44cfea5c06c2a002f8b00d527118aab4368b0cc7766cec025ed2365f1e641580",
+            "store.py": "fc3f22042dc9c8ce53964610361c4c39f52184832a31dd91cef0cd42e701f900",
         }
         entries = list(vendored.rglob("*"))
         for path in entries:

--- a/test_team_hub_managed_host.py
+++ b/test_team_hub_managed_host.py
@@ -73,6 +73,8 @@ def replace_then_crash(source, target):
         os._exit(72)
 
 def write_journal_then_crash(root, journal):
+    if crash_point == "prejournal" and journal["state"] == "prepared":
+        os._exit(75)
     original_write_journal(root, journal)
     if crash_point == "commit" and journal["state"] == "committed":
         os._exit(73)
@@ -1047,6 +1049,73 @@ sys.exit(10)
                 ):
                     HubStore(data_dir, managed_host_identity=HOST_A)
             preflight.assert_not_called()
+            self.assertEqual(store.database_path.read_bytes(), database_before)
+
+    def test_prejournal_restore_crash_is_cleaned_before_database_open(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            data_dir = Path(temporary) / "hub"
+            store = HubStore(data_dir, managed_host_identity=HOST_A)
+            hub_id = store.hub_id
+            operation_id = "restore-crash-prejournal"
+            snapshot = store.maintenance_snapshot_and_fence(
+                "server-update",
+                operation_id=operation_id,
+            )
+            live_before = {
+                "database": store.database_path.read_bytes(),
+                "key": store.signing_key_path.read_bytes(),
+                "proof": store.bootstrap_proof_path.read_bytes(),
+                "fence": store.maintenance_fence_path.read_bytes(),
+            }
+
+            crashed = self.run_restore_until_crash(
+                data_dir,
+                snapshot,
+                hub_id=hub_id,
+                operation_id=operation_id,
+                crash_point="prejournal",
+            )
+            self.assertEqual(crashed.returncode, 75, crashed.stderr)
+            self.assertFalse((data_dir / ".restore-transaction.json").exists())
+            self.assertEqual(len(list(data_dir.glob(".restore-[0-9]*-*"))), 1)
+
+            recovered = HubStore(data_dir, managed_host_identity=HOST_A)
+            self.assertEqual(recovered.hub_id, hub_id)
+            self.assertEqual(store.database_path.read_bytes(), live_before["database"])
+            self.assertEqual(store.signing_key_path.read_bytes(), live_before["key"])
+            self.assertEqual(store.bootstrap_proof_path.read_bytes(), live_before["proof"])
+            self.assertEqual(store.maintenance_fence_path.read_bytes(), live_before["fence"])
+            self.assertEqual(list(data_dir.glob(".restore-[0-9]*-*")), [])
+
+            reopened = HubStore(data_dir, managed_host_identity=HOST_A)
+            self.assertEqual(reopened.hub_id, hub_id)
+            self.assertEqual(list(data_dir.glob(".restore-[0-9]*-*")), [])
+
+    def test_unsafe_orphan_restore_generation_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            data_dir = root / "hub"
+            store = HubStore(data_dir, managed_host_identity=HOST_A)
+            database_before = store.database_path.read_bytes()
+            outside = root / "outside"
+            outside.mkdir()
+            marker = outside / "keep.txt"
+            marker.write_text("do not delete", encoding="utf-8")
+            orphan = data_dir / ".restore-999-0123456789abcdef"
+            orphan.symlink_to(outside, target_is_directory=True)
+
+            with mock.patch.object(
+                HubStore,
+                "_preflight_managed_host_binding",
+            ) as preflight:
+                with self.assertRaisesRegex(
+                    PermissionError,
+                    "restore transaction target is unsafe",
+                ):
+                    HubStore(data_dir, managed_host_identity=HOST_A)
+            preflight.assert_not_called()
+            self.assertTrue(orphan.is_symlink())
+            self.assertEqual(marker.read_text(encoding="utf-8"), "do not delete")
             self.assertEqual(store.database_path.read_bytes(), database_before)
 
     def test_offline_restore_verifies_identity_and_restores_db_key_and_proofs(self) -> None:

--- a/test_team_hub_managed_host.py
+++ b/test_team_hub_managed_host.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from dataclasses import replace
 import hashlib
 import json
+import os
 from pathlib import Path
 import shutil
 import sqlite3
+import subprocess
+import sys
 import tempfile
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -26,6 +29,126 @@ HOST_B = "server-host-b-12345678"
 
 
 class ManagedHostTests(unittest.TestCase):
+    @staticmethod
+    def run_restore_until_crash(
+        data_dir: Path,
+        snapshot: Path,
+        *,
+        hub_id: str,
+        operation_id: str,
+        crash_point: str,
+    ) -> subprocess.CompletedProcess[str]:
+        script = r"""
+import os
+from pathlib import Path
+import sys
+from unittest import mock
+
+from agentsdock_team_hub.store import HubStore
+
+data_dir = Path(sys.argv[1])
+snapshot = Path(sys.argv[2])
+hub_id = sys.argv[3]
+operation_id = sys.argv[4]
+crash_point = sys.argv[5]
+original_replace = os.replace
+original_write_journal = HubStore._write_restore_transaction_journal
+
+def replace_then_crash(source, target):
+    original_replace(source, target)
+    source_path = Path(source)
+    target_path = Path(target)
+    if (
+        crash_point == "retire"
+        and target_path.parent.name == "previous"
+        and target_path.name == "team-hub.sqlite3"
+    ):
+        os._exit(71)
+    if (
+        crash_point == "install"
+        and target_path.parent == data_dir
+        and target_path.name == "access-token-signing.key"
+        and source_path.parent.name.startswith(".restore-")
+    ):
+        os._exit(72)
+
+def write_journal_then_crash(root, journal):
+    original_write_journal(root, journal)
+    if crash_point == "commit" and journal["state"] == "committed":
+        os._exit(73)
+
+with mock.patch(
+    "agentsdock_team_hub.store.os.replace", side_effect=replace_then_crash
+), mock.patch.object(
+    HubStore,
+    "_write_restore_transaction_journal",
+    side_effect=write_journal_then_crash,
+):
+    HubStore.restore_maintenance_snapshot(
+        data_dir,
+        snapshot,
+        expected_host_identity=sys.argv[6],
+        expected_hub_id=hub_id,
+        expected_operation_id=operation_id,
+    )
+sys.exit(10)
+"""
+        return subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                script,
+                str(data_dir),
+                str(snapshot),
+                hub_id,
+                operation_id,
+                crash_point,
+                HOST_A,
+            ],
+            cwd=Path(__file__).parent,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    @staticmethod
+    def run_recovery_until_crash(data_dir: Path) -> subprocess.CompletedProcess[str]:
+        script = r"""
+import os
+from pathlib import Path
+import sys
+from unittest import mock
+
+from agentsdock_team_hub.store import HubStore
+
+data_dir = Path(sys.argv[1])
+original_replace = os.replace
+
+def replace_then_crash(source, target):
+    original_replace(source, target)
+    source_path = Path(source)
+    target_path = Path(target)
+    if (
+        source_path.parent.name == "previous"
+        and target_path.parent == data_dir
+        and target_path.name == "team-hub.sqlite3"
+    ):
+        os._exit(74)
+
+with mock.patch(
+    "agentsdock_team_hub.store.os.replace", side_effect=replace_then_crash
+):
+    HubStore(data_dir, managed_host_identity=sys.argv[2])
+sys.exit(10)
+"""
+        return subprocess.run(
+            [sys.executable, "-c", script, str(data_dir), HOST_A],
+            cwd=Path(__file__).parent,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
     def test_managed_server_mount_health_requires_issuable_claims(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             application = create_app(
@@ -735,14 +858,18 @@ class ManagedHostTests(unittest.TestCase):
                 "fence": store.maintenance_fence_path.read_bytes(),
                 "attachment": live_path.read_bytes(),
             }
-            original_fsync = HubStore._fsync_directory
+            original_write_journal = HubStore._write_restore_transaction_journal
 
-            def fail_commit(path: Path) -> None:
-                if Path(path) == data_dir:
+            def fail_commit(path: Path, journal: dict[str, object]) -> None:
+                if journal["state"] == "committed":
                     raise OSError("forced restore commit failure")
-                original_fsync(path)
+                original_write_journal(path, journal)
 
-            with mock.patch.object(HubStore, "_fsync_directory", side_effect=fail_commit):
+            with mock.patch.object(
+                HubStore,
+                "_write_restore_transaction_journal",
+                side_effect=fail_commit,
+            ):
                 with self.assertRaisesRegex(OSError, "forced restore commit failure"):
                     HubStore.restore_maintenance_snapshot(
                         data_dir,
@@ -756,6 +883,171 @@ class ManagedHostTests(unittest.TestCase):
             self.assertEqual(store.maintenance_fence_path.read_bytes(), live_before["fence"])
             self.assertEqual(live_path.read_bytes(), live_before["attachment"])
             self.assertEqual(list(data_dir.glob(".restore-*")), [])
+
+    def test_restore_crash_recovery_rolls_back_or_commits_one_exact_generation(self) -> None:
+        expected_exit = {"retire": 71, "install": 72, "commit": 73}
+        for crash_point in expected_exit:
+            with self.subTest(crash_point=crash_point), tempfile.TemporaryDirectory() as temporary:
+                data_dir = Path(temporary) / "hub"
+                store = HubStore(data_dir, managed_host_identity=HOST_A)
+                proof = store.bootstrap_proof_path.read_text().strip()
+                bundle = store.bootstrap(
+                    proof,
+                    "owner@example.com",
+                    "Owner",
+                    "Owner Mac",
+                )
+                claims = store.verify_access(bundle["access_token"])
+                team_id = bundle["teams"][0]["id"]
+
+                snapshot_bytes = b"snapshot generation attachment"
+                snapshot_digest = hashlib.sha256(snapshot_bytes).hexdigest()
+                snapshot_attachment = store.declare_team_attachment(
+                    claims,
+                    team_id,
+                    {
+                        "file_name": "snapshot.txt",
+                        "media_type": "text/plain",
+                        "byte_size": len(snapshot_bytes),
+                        "sha256": snapshot_digest,
+                        "idempotency_key": f"restore-crash-snapshot-{crash_point}",
+                    },
+                )["attachment"]
+                store.write_team_attachment_chunk(
+                    claims,
+                    team_id,
+                    snapshot_attachment["id"],
+                    offset=0,
+                    total=len(snapshot_bytes),
+                    data=snapshot_bytes,
+                )
+                operation_id = f"restore-crash-{crash_point}"
+                snapshot = store.maintenance_snapshot_and_fence(
+                    "server-update",
+                    operation_id=operation_id,
+                )
+                fence_bytes = store.maintenance_fence_path.read_bytes()
+                self.assertTrue(
+                    store.clear_maintenance_fence(
+                        expected_reason="server-update",
+                        expected_operation_id=operation_id,
+                        expected_snapshot=snapshot,
+                    )
+                )
+
+                candidate_bytes = b"candidate generation attachment"
+                candidate_digest = hashlib.sha256(candidate_bytes).hexdigest()
+                candidate_attachment = store.declare_team_attachment(
+                    claims,
+                    team_id,
+                    {
+                        "file_name": "candidate.txt",
+                        "media_type": "text/plain",
+                        "byte_size": len(candidate_bytes),
+                        "sha256": candidate_digest,
+                        "idempotency_key": f"restore-crash-candidate-{crash_point}",
+                    },
+                )["attachment"]
+                store.write_team_attachment_chunk(
+                    claims,
+                    team_id,
+                    candidate_attachment["id"],
+                    offset=0,
+                    total=len(candidate_bytes),
+                    data=candidate_bytes,
+                )
+                store.maintenance_fence_path.write_bytes(fence_bytes)
+                store.maintenance_fence_path.chmod(0o600)
+
+                crashed = self.run_restore_until_crash(
+                    data_dir,
+                    snapshot,
+                    hub_id=store.hub_id,
+                    operation_id=operation_id,
+                    crash_point=crash_point,
+                )
+                self.assertEqual(
+                    crashed.returncode,
+                    expected_exit[crash_point],
+                    crashed.stderr,
+                )
+                self.assertTrue(
+                    (data_dir / ".restore-transaction.json").exists()
+                )
+
+                if crash_point == "install":
+                    recovery_crashed = self.run_recovery_until_crash(data_dir)
+                    self.assertEqual(
+                        recovery_crashed.returncode,
+                        74,
+                        recovery_crashed.stderr,
+                    )
+                    self.assertTrue(
+                        (data_dir / ".restore-transaction.json").exists()
+                    )
+
+                recovered = HubStore(data_dir, managed_host_identity=HOST_A)
+                connection = recovered.connect()
+                try:
+                    attachment_ids = {
+                        str(row["id"])
+                        for row in connection.execute(
+                            "SELECT id FROM team_attachments"
+                        )
+                    }
+                finally:
+                    connection.close()
+                snapshot_path = (
+                    data_dir / "attachments" / snapshot_digest[:2] / snapshot_digest
+                )
+                candidate_path = (
+                    data_dir / "attachments" / candidate_digest[:2] / candidate_digest
+                )
+                if crash_point == "commit":
+                    self.assertEqual(attachment_ids, {snapshot_attachment["id"]})
+                    self.assertFalse(candidate_path.exists())
+                    self.assertIsNone(recovered.maintenance_fence())
+                else:
+                    self.assertEqual(
+                        attachment_ids,
+                        {snapshot_attachment["id"], candidate_attachment["id"]},
+                    )
+                    self.assertEqual(candidate_path.read_bytes(), candidate_bytes)
+                    self.assertIsNotNone(recovered.maintenance_fence())
+                self.assertEqual(snapshot_path.read_bytes(), snapshot_bytes)
+                self.assertFalse(
+                    (data_dir / ".restore-transaction.json").exists()
+                )
+                self.assertEqual(list(data_dir.glob(".restore-[0-9]*-*")), [])
+
+                # Recovery is a no-op after completion and cannot flip the
+                # chosen generation on a later open.
+                reopened = HubStore(data_dir, managed_host_identity=HOST_A)
+                self.assertEqual(
+                    reopened.maintenance_fence() is None,
+                    crash_point == "commit",
+                )
+
+    def test_invalid_restore_journal_fails_closed_before_database_preflight(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            data_dir = Path(temporary) / "hub"
+            store = HubStore(data_dir, managed_host_identity=HOST_A)
+            database_before = store.database_path.read_bytes()
+            journal = data_dir / ".restore-transaction.json"
+            journal.write_text("{}\n", encoding="utf-8")
+            journal.chmod(0o600)
+
+            with mock.patch.object(
+                HubStore,
+                "_preflight_managed_host_binding",
+            ) as preflight:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "restore transaction journal is invalid",
+                ):
+                    HubStore(data_dir, managed_host_identity=HOST_A)
+            preflight.assert_not_called()
+            self.assertEqual(store.database_path.read_bytes(), database_before)
 
     def test_offline_restore_verifies_identity_and_restores_db_key_and_proofs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/test_team_hub_managed_host.py
+++ b/test_team_hub_managed_host.py
@@ -506,6 +506,257 @@ class ManagedHostTests(unittest.TestCase):
             generations = list((data_dir / "maintenance-backups").glob("snapshot_*"))
             self.assertEqual(len(generations), 3)
 
+    def test_snapshot_restores_ready_and_resumable_attachment_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            data_dir = Path(temporary) / "hub"
+            store = HubStore(data_dir, managed_host_identity=HOST_A)
+            proof = store.bootstrap_proof_path.read_text().strip()
+            bundle = store.bootstrap(
+                proof,
+                "owner@example.com",
+                "Owner",
+                "Owner Mac",
+            )
+            claims = store.verify_access(bundle["access_token"])
+            team_id = bundle["teams"][0]["id"]
+
+            ready_bytes = b"ready attachment generation"
+            ready_digest = hashlib.sha256(ready_bytes).hexdigest()
+            ready = store.declare_team_attachment(
+                claims,
+                team_id,
+                {
+                    "file_name": "ready.txt",
+                    "media_type": "text/plain",
+                    "byte_size": len(ready_bytes),
+                    "sha256": ready_digest,
+                    "idempotency_key": "snapshot-ready-attachment",
+                },
+            )["attachment"]
+            store.write_team_attachment_chunk(
+                claims,
+                team_id,
+                ready["id"],
+                offset=0,
+                total=len(ready_bytes),
+                data=ready_bytes,
+            )
+
+            pending_bytes = b"resumable attachment generation"
+            pending_digest = hashlib.sha256(pending_bytes).hexdigest()
+            pending = store.declare_team_attachment(
+                claims,
+                team_id,
+                {
+                    "file_name": "pending.txt",
+                    "media_type": "text/plain",
+                    "byte_size": len(pending_bytes),
+                    "sha256": pending_digest,
+                    "idempotency_key": "snapshot-pending-attachment",
+                },
+            )["attachment"]
+            prefix = pending_bytes[:11]
+            store.write_team_attachment_chunk(
+                claims,
+                team_id,
+                pending["id"],
+                offset=0,
+                total=len(pending_bytes),
+                data=prefix,
+            )
+
+            snapshot = store.maintenance_snapshot_and_fence(
+                "server-update",
+                operation_id="update-attachments",
+            )
+            manifest = json.loads((snapshot / "manifest.json").read_text())
+            self.assertEqual(manifest["format"], 2)
+            self.assertEqual(manifest["attachments"]["file_count"], 2)
+            self.assertEqual(
+                manifest["attachments"]["byte_size"],
+                len(ready_bytes) + len(prefix),
+            )
+            snapshot_ready = snapshot / "attachments" / ready_digest[:2] / ready_digest
+            snapshot_pending = (
+                snapshot / "attachments" / "uploads" / f"{pending['id']}.part"
+            )
+            self.assertEqual(snapshot_ready.read_bytes(), ready_bytes)
+            self.assertEqual(snapshot_pending.read_bytes(), prefix)
+            HubStore.verify_maintenance_snapshot(
+                data_dir,
+                snapshot,
+                expected_host_identity=HOST_A,
+                expected_hub_id=store.hub_id,
+                expected_operation_id="update-attachments",
+            )
+
+            live_ready = data_dir / "attachments" / ready_digest[:2] / ready_digest
+            live_pending = data_dir / "attachments" / "uploads" / f"{pending['id']}.part"
+            live_ready.write_bytes(b"x" * len(ready_bytes))
+            live_pending.write_bytes(b"y" * len(prefix))
+            extra = data_dir / "attachments" / "uploads" / "newer.part"
+            extra.write_bytes(b"newer generation")
+            extra.chmod(0o600)
+
+            HubStore.restore_maintenance_snapshot(
+                data_dir,
+                snapshot,
+                expected_host_identity=HOST_A,
+                expected_hub_id=store.hub_id,
+                expected_operation_id="update-attachments",
+            )
+            self.assertEqual(live_ready.read_bytes(), ready_bytes)
+            self.assertEqual(live_pending.read_bytes(), prefix)
+            self.assertFalse(extra.exists())
+            connection = sqlite3.connect(data_dir / "team-hub.sqlite3")
+            try:
+                self.assertEqual(
+                    connection.execute(
+                        "SELECT state,received_bytes FROM team_attachments WHERE id=?",
+                        (ready["id"],),
+                    ).fetchone(),
+                    ("ready", len(ready_bytes)),
+                )
+                self.assertEqual(
+                    connection.execute(
+                        "SELECT state,received_bytes FROM team_attachments WHERE id=?",
+                        (pending["id"],),
+                    ).fetchone(),
+                    ("uploading", len(prefix)),
+                )
+            finally:
+                connection.close()
+
+    def test_snapshot_rejects_missing_attachment_before_live_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            data_dir = Path(temporary) / "hub"
+            store = HubStore(data_dir, managed_host_identity=HOST_A)
+            proof = store.bootstrap_proof_path.read_text().strip()
+            bundle = store.bootstrap(
+                proof,
+                "owner@example.com",
+                "Owner",
+                "Owner Mac",
+            )
+            claims = store.verify_access(bundle["access_token"])
+            team_id = bundle["teams"][0]["id"]
+            payload = b"must remain available"
+            digest = hashlib.sha256(payload).hexdigest()
+            attachment = store.declare_team_attachment(
+                claims,
+                team_id,
+                {
+                    "file_name": "required.txt",
+                    "media_type": "text/plain",
+                    "byte_size": len(payload),
+                    "sha256": digest,
+                    "idempotency_key": "snapshot-required-attachment",
+                },
+            )["attachment"]
+            store.write_team_attachment_chunk(
+                claims,
+                team_id,
+                attachment["id"],
+                offset=0,
+                total=len(payload),
+                data=payload,
+            )
+            snapshot = store.maintenance_snapshot_and_fence(
+                "server-update",
+                operation_id="update-missing-attachment",
+            )
+            live_path = data_dir / "attachments" / digest[:2] / digest
+            live_before = {
+                "database": store.database_path.read_bytes(),
+                "key": store.signing_key_path.read_bytes(),
+                "fence": store.maintenance_fence_path.read_bytes(),
+                "attachment": live_path.read_bytes(),
+            }
+            (snapshot / "attachments" / digest[:2] / digest).unlink()
+
+            with self.assertRaisesRegex(RuntimeError, "attachment tree"):
+                HubStore.verify_maintenance_snapshot(
+                    data_dir,
+                    snapshot,
+                    expected_host_identity=HOST_A,
+                    expected_hub_id=store.hub_id,
+                    expected_operation_id="update-missing-attachment",
+                )
+            self.assertEqual(store.database_path.read_bytes(), live_before["database"])
+            self.assertEqual(store.signing_key_path.read_bytes(), live_before["key"])
+            self.assertEqual(store.maintenance_fence_path.read_bytes(), live_before["fence"])
+            self.assertEqual(live_path.read_bytes(), live_before["attachment"])
+
+    def test_attachment_directory_rolls_back_after_restore_install_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            data_dir = Path(temporary) / "hub"
+            store = HubStore(data_dir, managed_host_identity=HOST_A)
+            proof = store.bootstrap_proof_path.read_text().strip()
+            bundle = store.bootstrap(
+                proof,
+                "owner@example.com",
+                "Owner",
+                "Owner Mac",
+            )
+            claims = store.verify_access(bundle["access_token"])
+            team_id = bundle["teams"][0]["id"]
+            payload = b"snapshot attachment"
+            digest = hashlib.sha256(payload).hexdigest()
+            attachment = store.declare_team_attachment(
+                claims,
+                team_id,
+                {
+                    "file_name": "rollback.txt",
+                    "media_type": "text/plain",
+                    "byte_size": len(payload),
+                    "sha256": digest,
+                    "idempotency_key": "snapshot-rollback-attachment",
+                },
+            )["attachment"]
+            store.write_team_attachment_chunk(
+                claims,
+                team_id,
+                attachment["id"],
+                offset=0,
+                total=len(payload),
+                data=payload,
+            )
+            snapshot = store.maintenance_snapshot_and_fence(
+                "server-update",
+                operation_id="update-attachment-rollback",
+            )
+            live_path = data_dir / "attachments" / digest[:2] / digest
+            changed = b"changed attachment!"
+            self.assertEqual(len(changed), len(payload))
+            live_path.write_bytes(changed)
+            live_before = {
+                "database": store.database_path.read_bytes(),
+                "key": store.signing_key_path.read_bytes(),
+                "fence": store.maintenance_fence_path.read_bytes(),
+                "attachment": live_path.read_bytes(),
+            }
+            original_fsync = HubStore._fsync_directory
+
+            def fail_commit(path: Path) -> None:
+                if Path(path) == data_dir:
+                    raise OSError("forced restore commit failure")
+                original_fsync(path)
+
+            with mock.patch.object(HubStore, "_fsync_directory", side_effect=fail_commit):
+                with self.assertRaisesRegex(OSError, "forced restore commit failure"):
+                    HubStore.restore_maintenance_snapshot(
+                        data_dir,
+                        snapshot,
+                        expected_host_identity=HOST_A,
+                        expected_hub_id=store.hub_id,
+                        expected_operation_id="update-attachment-rollback",
+                    )
+            self.assertEqual(store.database_path.read_bytes(), live_before["database"])
+            self.assertEqual(store.signing_key_path.read_bytes(), live_before["key"])
+            self.assertEqual(store.maintenance_fence_path.read_bytes(), live_before["fence"])
+            self.assertEqual(live_path.read_bytes(), live_before["attachment"])
+            self.assertEqual(list(data_dir.glob(".restore-*")), [])
+
     def test_offline_restore_verifies_identity_and_restores_db_key_and_proofs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             data_dir = Path(temporary) / "hub"

--- a/test_team_messages.py
+++ b/test_team_messages.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import tempfile
 import unittest
 import uuid
+from unittest import mock
 
 from fastapi.testclient import TestClient
 
@@ -292,6 +293,133 @@ class TeamMessagesServiceTests(unittest.TestCase):
         self.assertEqual(len(filtered["messages"]), 1)
         future = self.get(self.member, f"{self.base}/messages?box=inbox&since=2999-01-01T00:00:00Z")
         self.assertEqual(future["messages"], [])
+
+    def test_receipt_outbox_is_atomic_per_recipient_and_idempotent(self) -> None:
+        member_id = self.member["principal"]["id"]
+        sent = self.send(self.owner, [{"kind": "human", "id": member_id}])
+        store = self.app.state.store
+        connection = store.connect()
+        try:
+            recipient_id = str(
+                connection.execute(
+                    "SELECT id FROM team_message_recipients WHERE message_id=?",
+                    (sent["id"],),
+                ).fetchone()[0]
+            )
+        finally:
+            connection.close()
+
+        delivered_key = _key()
+        delivered_request = {
+            "state": "delivered",
+            "idempotency_key": delivered_key,
+        }
+        with mock.patch.object(
+            store,
+            "_outbox",
+            side_effect=RuntimeError("forced receipt outbox failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "forced receipt outbox failure"):
+                self.client.post(
+                    f"{self.base}/messages/{sent['id']}/receipts",
+                    headers=self.auth(self.member),
+                    json=delivered_request,
+                )
+
+        connection = store.connect()
+        try:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT state FROM team_message_recipients WHERE id=?",
+                    (recipient_id,),
+                ).fetchone()[0],
+                "available",
+            )
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM audit_events WHERE action='team.message.receipt'"
+                ).fetchone()[0],
+                0,
+            )
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM request_idempotency "
+                    "WHERE operation='team.message.receipt'"
+                ).fetchone()[0],
+                0,
+            )
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM outbox_events "
+                    "WHERE aggregate_type='team_message_recipient' AND aggregate_id=?",
+                    (recipient_id,),
+                ).fetchone()[0],
+                0,
+            )
+        finally:
+            connection.close()
+
+        first = self.post(
+            self.member,
+            f"{self.base}/messages/{sent['id']}/receipts",
+            delivered_request,
+        )
+        replay = self.post(
+            self.member,
+            f"{self.base}/messages/{sent['id']}/receipts",
+            delivered_request,
+        )
+        self.assertEqual(first, replay)
+        read_key = _key()
+        read_request = {"state": "read", "idempotency_key": read_key}
+        self.post(
+            self.member,
+            f"{self.base}/messages/{sent['id']}/receipts",
+            read_request,
+        )
+        self.post(
+            self.member,
+            f"{self.base}/messages/{sent['id']}/receipts",
+            read_request,
+        )
+        # A monotonic no-op under a distinct request key is audited but does
+        # not claim another state-change effect in the outbox.
+        self.post(
+            self.member,
+            f"{self.base}/messages/{sent['id']}/receipts",
+            {"state": "delivered", "idempotency_key": _key()},
+        )
+
+        connection = store.connect()
+        try:
+            events = connection.execute(
+                """
+                SELECT aggregate_type,aggregate_id,event_type,state
+                FROM outbox_events
+                WHERE aggregate_type='team_message_recipient' AND aggregate_id=?
+                ORDER BY created_at,event_type
+                """,
+                (recipient_id,),
+            ).fetchall()
+            self.assertEqual(
+                [tuple(row) for row in events],
+                [
+                    (
+                        "team_message_recipient",
+                        recipient_id,
+                        "team.message.delivered",
+                        "pending",
+                    ),
+                    (
+                        "team_message_recipient",
+                        recipient_id,
+                        "team.message.read",
+                        "pending",
+                    ),
+                ],
+            )
+        finally:
+            connection.close()
 
     def test_inbox_delivery_matches_the_requested_owned_address(self) -> None:
         member_id = self.member["principal"]["id"]
@@ -629,6 +757,88 @@ class TeamMessagesServiceTests(unittest.TestCase):
         duplicate = self.declare(self.owner, payload, name="copy.bin")["attachment"]
         self.assertEqual(duplicate["state"], "ready")
         self.assertEqual(duplicate["received_bytes"], len(payload))
+
+    def test_attachment_declaration_outbox_is_atomic_and_idempotent(self) -> None:
+        payload = b"declaration outbox"
+        request = {
+            "file_name": "outbox.txt",
+            "media_type": "text/plain",
+            "byte_size": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "idempotency_key": _key(),
+        }
+        store = self.app.state.store
+        with mock.patch.object(
+            store,
+            "_outbox",
+            side_effect=RuntimeError("forced declaration outbox failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "forced declaration outbox failure"):
+                self.client.post(
+                    f"{self.base}/attachments",
+                    headers=self.auth(self.owner),
+                    json=request,
+                )
+
+        connection = store.connect()
+        try:
+            self.assertEqual(
+                connection.execute("SELECT COUNT(*) FROM team_attachments").fetchone()[0],
+                0,
+            )
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM audit_events "
+                    "WHERE action='team.attachment.declare'"
+                ).fetchone()[0],
+                0,
+            )
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM request_idempotency "
+                    "WHERE operation='team.attachment.declare'"
+                ).fetchone()[0],
+                0,
+            )
+        finally:
+            connection.close()
+
+        first = self.post(self.owner, f"{self.base}/attachments", request)
+        replay = self.post(self.owner, f"{self.base}/attachments", request)
+        self.assertEqual(first, replay)
+        attachment_id = first["attachment"]["id"]
+        connection = store.connect()
+        try:
+            events = connection.execute(
+                """
+                SELECT aggregate_type,aggregate_id,event_type,state
+                FROM outbox_events
+                WHERE aggregate_type='team_attachment' AND aggregate_id=?
+                  AND event_type='team.attachment.declared'
+                """,
+                (attachment_id,),
+            ).fetchall()
+            self.assertEqual(
+                [tuple(row) for row in events],
+                [
+                    (
+                        "team_attachment",
+                        attachment_id,
+                        "team.attachment.declared",
+                        "pending",
+                    )
+                ],
+            )
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM audit_events "
+                    "WHERE action='team.attachment.declare' AND resource_id=?",
+                    (attachment_id,),
+                ).fetchone()[0],
+                1,
+            )
+        finally:
+            connection.close()
 
     def test_attachment_hash_mismatch_fails_closed(self) -> None:
         payload = b"x" * 3000


### PR DESCRIPTION
Completes the remaining Team Messages V2 backend hardening after PRs #68 and #69.

- Discover the account-authorized Claude catalog dynamically while keeping aliases visible.
- Keep credentials out of argv/environment/disk, reject insecure remote HTTP, bypass curl config and proxies, and bound discovery by a total deadline.
- Make Team attachment declarations and receipts durable through a transactional outbox.
- Make Team Hub restore generations crash-atomic with journaled recovery.
- Detect and safely clean abandoned pre-journal restore stages.

Validation: 1,950 tests passed with 4 expected skips; package archive validation passed. This PR does not tag, publish, install, deploy, or restart a server.