### PR TITLE
Complete Claude live forks with imported history checkpoints

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -77928,6 +77928,69 @@ def completed_fork_events(
     return prefix[:completed_length]
 
 
+def claude_imported_fork_boundary(
+    parent: dict[str, Any],
+    provider_id: str,
+    events: list[dict[str, Any]],
+) -> str:
+    """Recover native completion from an import's durable transcript checkpoint.
+
+    Import terminals are bookkeeping, not provider turns. Their saved byte
+    prefix must end at an explicit native completion before it can be forked.
+    Later source appends are allowed; none are read into this snapshot.
+    """
+    run_id = str(events[-1].get("run_id") or "")
+    batch = [event for event in events if str(event.get("run_id") or "") == run_id]
+    marker = next((event for event in batch if event.get("type") == "history_imported"), {})
+    checkpoint = marker.get("_history_sync_checkpoint")
+    if not isinstance(checkpoint, dict) or checkpoint.get("caught_up") is not True:
+        raise ValueError("imported history has no complete native checkpoint")
+    cursor = normalized_history_sync_cursor({**parent, "_history_sync_cursor": checkpoint.get("cursor")})
+    if cursor is None or cursor["backend"] != BACKEND_CLAUDE or cursor["provider_session_id"] != provider_id:
+        raise ValueError("imported history checkpoint belongs to a different provider")
+    path = contained_jsonl_path(Path(cursor["source_path"]), CLAUDE_PROJECTS_ROOT)
+    if path is None:
+        raise ValueError("imported history checkpoint transcript is unavailable")
+    remaining = int(cursor["source_offset"])
+    digest = hashlib.sha256()
+    last_message: dict[str, Any] = {}
+    with path.open("rb") as stream:
+        for _line in range(MAX_LOCAL_TRANSCRIPT_SCAN_LINES):
+            if not remaining:
+                break
+            raw = stream.readline(min(MAX_LOCAL_TRANSCRIPT_LINE_BYTES + 1, remaining))
+            if not raw or not raw.endswith(b"\n") or len(raw) > MAX_LOCAL_TRANSCRIPT_LINE_BYTES:
+                raise ValueError("imported history checkpoint has an incomplete transcript record")
+            remaining -= len(raw)
+            digest.update(raw)
+            if not raw.strip():
+                continue
+            record = json.loads(raw)
+            if isinstance(record, dict) and record.get("type") in {"user", "assistant"} and not record.get("isSidechain"):
+                last_message = record
+    if remaining or not hmac.compare_digest(digest.hexdigest(), cursor["source_digest"]):
+        raise ValueError("imported history checkpoint no longer matches its native prefix")
+    message = last_message.get("message")
+    cutoff = str(last_message.get("uuid") or "")
+    native_time = parse_job_timestamp(str(last_message.get("timestamp") or ""))
+    imported_time = parse_job_timestamp(str(events[-1].get("ts") or ""))
+    if (
+        last_message.get("type") != "assistant" or not cutoff
+        or not isinstance(message, dict) or message.get("stop_reason") != "end_turn"
+        or native_time is None or imported_time is None or native_time > imported_time
+    ):
+        raise ValueError("imported history does not end at a completed native assistant turn")
+    visible = [event for event in batch if event.get("type") in {"turn_started", "assistant_text"}]
+    native_item = claude_history_event_item(last_message, expected_session_id=str(parent.get("id") or ""))
+    if (
+        not visible or visible[-1].get("type") != "assistant_text"
+        or native_item is None
+        or native_item.get("text") != str(visible[-1].get("text") or "")
+    ):
+        raise ValueError("imported visible history does not match the native completed boundary")
+    return cutoff
+
+
 def claude_completed_fork_boundary(
     parent: dict[str, Any],
     provider_id: str,
@@ -77939,6 +78002,8 @@ def claude_completed_fork_boundary(
     before the durable terminal timestamp; never take the transcript's tail.
     """
     terminal = events[-1]
+    if terminal.get("imported") is True:
+        return claude_imported_fork_boundary(parent, provider_id, events)
     run_id = str(terminal.get("run_id") or "")
     completed_provider = str(terminal.get("provider_session_id") or "")
     if completed_provider and completed_provider != provider_id:

--- a/test_live_session_fork.py
+++ b/test_live_session_fork.py
@@ -1,4 +1,7 @@
 import asyncio
+import hashlib
+import json
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -110,3 +113,40 @@ class CompletedPrefixForkTests(unittest.IsolatedAsyncioTestCase):
     def test_claude_missing_deferred_snapshot_never_launches_fresh(self):
         with self.assertRaisesRegex(ValueError, "refusing an empty resume"):
             server.build_claude_cmd("child", {"fork_from": "parent", "fork_resume_session_at": "uuid"}, Path("manifest"))
+
+    def test_imported_checkpoint_proves_exact_completed_tail_despite_later_live_append(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / "provider.jsonl"
+            parent = {"id": "parent", "backend": "claude", "claude_session_id": "provider", "cwd": str(root)}
+            native = {
+                "type": "assistant", "uuid": "completed-uuid", "timestamp": "2026-09-08T10:00:40Z",
+                "message": {"stop_reason": "end_turn", "content": [{"type": "text", "text": "Completed answer"}]},
+            }
+            for invalid in (None, "partial", "later-user", "changed-prefix"):
+                with self.subTest(invalid=invalid):
+                    record = {**native, "message": {**native["message"], "stop_reason": None}} if invalid == "partial" else native
+                    prefix = (json.dumps(record) + "\n").encode()
+                    if invalid == "later-user":
+                        prefix += (json.dumps({"type": "user", "message": {"content": "New incomplete turn"}}) + "\n").encode()
+                    path.write_bytes(prefix + b'{"type":"user","message":{"content":"LIVE: must not copy"}}\n')
+                    stat = path.stat()
+                    cursor = {
+                        "version": server.HISTORY_SYNC_CURSOR_VERSION, "backend": "claude", "provider_session_id": "provider",
+                        "source_path": str(path), "source_dev": stat.st_dev, "source_ino": stat.st_ino,
+                        "source_size": len(prefix), "source_offset": len(prefix), "source_mtime_ns": stat.st_mtime_ns,
+                        "source_digest": "0" * 64 if invalid == "changed-prefix" else hashlib.sha256(prefix).hexdigest(),
+                        "last_item_digest": "", "timeline_seq": 3,
+                    }
+                    events = [
+                        {"seq": 1, "type": "history_imported", "run_id": "import", "_history_sync_checkpoint": {"caught_up": True, "cursor": cursor}},
+                        {"seq": 2, "type": "assistant_text", "run_id": "import", "imported": True, "text": "Completed answer"},
+                        {"seq": 3, "type": "turn_finished", "run_id": "import", "imported": True, "result_text": "", "ts": "2026-09-08T10:42:00Z"},
+                    ]
+                    with patch.object(server, "CLAUDE_PROJECTS_ROOT", root):
+                        if invalid:
+                            with self.assertRaises(ValueError):
+                                server.claude_completed_fork_boundary(parent, "provider", events)
+                        else:
+                            self.assertEqual(server.claude_completed_fork_boundary(parent, "provider", events), "completed-uuid")
+                    self.assertEqual(events[-1]["seq"], 3)


### PR DESCRIPTION
Resolve live-fork boundaries using the durable verified transcript checkpoint for imported Claude history. Preserve the complete visible history, exclude live appends, and fail closed if the native cutoff cannot be proved. Read-only validated against the reported CMA-ES Scalable chat; focused fork regressions pass. This final correction completes the pending beta.50 deployment candidate.