### PR TITLE
Let a completed Codex sign-in take effect

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -60328,6 +60328,13 @@ async def run_codex_app_server(
     })
 
     manager = await codex_app_server_manager()
+    # A sign-in that happened after this app-server started is invisible to it:
+    # it would keep refreshing the credentials it loaded at launch and fail the
+    # turn by asking the user to sign in again, which they already did. Retiring
+    # the idle process here lets the lazy restart below read the new
+    # credentials, so a completed sign-in takes effect with no user action.
+    with suppress(Exception):
+        await manager.retire_replaced_credentials()
     provider_id = str(session_provider_id(sess) or "")
     resumed_provider_id = provider_id or None
     model, effort, service_tier = codex_runtime_settings(sess)

--- a/codex_app_server.py
+++ b/codex_app_server.py
@@ -131,6 +131,32 @@ _REVIEW_TARGET_TYPES = frozenset(
 )
 
 
+CODEX_AUTH_FILE_NAME = "auth.json"
+
+
+def codex_auth_file_path(env: dict[str, str]) -> str:
+    """Resolve ``$CODEX_HOME/auth.json`` for the environment a child inherits."""
+
+    home = str(env.get("CODEX_HOME") or "").strip()
+    if not home:
+        home = os.path.join("~", ".codex")
+    return os.path.join(os.path.expanduser(home), CODEX_AUTH_FILE_NAME)
+
+
+def codex_auth_signature(path: str) -> tuple[int, int] | None:
+    """Return a cheap change signature for the credential file.
+
+    ``None`` means the file is absent or unreadable, which is never treated as
+    a change: an unreadable file cannot prove that newer credentials exist.
+    """
+
+    try:
+        stat_result = os.stat(path)
+    except OSError:
+        return None
+    return (stat_result.st_mtime_ns, stat_result.st_size)
+
+
 class _OmittedType:
     """Sentinel that distinguishes an omitted optional field from JSON null."""
 
@@ -543,6 +569,11 @@ class CodexAppServerClient:
         self._initialized = False
         self._initialize_result: dict[str, Any] | None = None
         self._generation = 0
+        # Codex reads its rotating OAuth credentials once per process, so the
+        # file a live child was launched against is the only thing that can
+        # tell us whether a later sign-in superseded what it holds.
+        self._auth_file: str | None = None
+        self._auth_signature: tuple[int, int] | None = None
 
     @property
     def ready(self) -> bool:
@@ -600,6 +631,13 @@ class CodexAppServerClient:
             ):
                 await self._discard_process()
             self._closing = False
+            env = self.env_factory()
+            auth_file = codex_auth_file_path(env)
+            # Sample before the spawn, never after.  A sign-in that lands
+            # during startup then merely looks newer than the process, which
+            # costs one redundant retire; sampling afterwards could record
+            # credentials the child never read and strand the user on them.
+            auth_signature = codex_auth_signature(auth_file)
             try:
                 proc = await self._process_factory(
                     self.codex_bin,
@@ -611,7 +649,7 @@ class CodexAppServerClient:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=self.cwd,
-                    env=self.env_factory(),
+                    env=env,
                     limit=self.process_stream_limit,
                     start_new_session=True,
                 )
@@ -634,6 +672,8 @@ class CodexAppServerClient:
                 else None
             )
             self._proc = proc
+            self._auth_file = auth_file
+            self._auth_signature = auth_signature
             if (
                 self._on_process_started is not None
                 and isinstance(raw_pid, int)
@@ -687,6 +727,31 @@ class CodexAppServerClient:
                 return False
             await self._discard_process()
             return True
+
+    async def retire_replaced_credentials(self) -> bool:
+        """Retire an idle process that is holding superseded credentials.
+
+        Codex loads ``auth.json`` once per process.  After an out-of-band
+        sign-in the live process keeps refreshing the credentials it already
+        holds and fails every turn with an authentication error asking the
+        user to sign in again - which no amount of signing in can fix, because
+        nothing tells the running child to re-read the file.  Retiring the
+        generation makes the next lazy ``start`` pick up the new credentials,
+        so the sign-in the user already completed simply takes effect.
+
+        Only an idle process is retired.  The shared app-server multiplexes
+        every Codex thread, so discarding it while turns are in flight would
+        kill work that may still be running fine on a valid in-memory token.
+        """
+
+        if not self.ready or self._auth_file is None:
+            return False
+        if self._turns_by_thread:
+            return False
+        current = codex_auth_signature(self._auth_file)
+        if current is None or current == self._auth_signature:
+            return False
+        return await self.retire_generation(self._generation)
 
     async def __aenter__(self) -> "CodexAppServerClient":
         await self.start()
@@ -2406,6 +2471,9 @@ class CodexAppServerManager:
 
     async def retire_generation(self, expected_generation: int) -> bool:
         return await self.client.retire_generation(expected_generation)
+
+    async def retire_replaced_credentials(self) -> bool:
+        return await self.client.retire_replaced_credentials()
 
     async def __aenter__(self) -> "CodexAppServerManager":
         await self.start()

--- a/test_codex_app_server.py
+++ b/test_codex_app_server.py
@@ -1,13 +1,17 @@
 import asyncio
 import json
+import os
 import signal
+import tempfile
 import time
 import unittest
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from codex_app_server import (
+    codex_auth_file_path,
     CodexAppServerClient,
     CodexAppServerDisconnected,
     CodexAppServerManager,
@@ -2228,6 +2232,161 @@ class CodexAppServerClientTests(unittest.IsolatedAsyncioTestCase):
             factory.process.messages[-1]["method"],
             "thread/compact/start",
         )
+
+
+class CodexCredentialRetirementTests(unittest.IsolatedAsyncioTestCase):
+    """Codex loads auth.json once per process; a later sign-in must land."""
+
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.codex_home = Path(directory.name)
+        self.auth_file = self.codex_home / "auth.json"
+
+    def write_credentials(self, token: str) -> None:
+        self.auth_file.write_text(json.dumps({"tokens": {"access": token}}))
+
+    def make_client(self, factory: FakeProcessFactory) -> CodexAppServerClient:
+        return CodexAppServerClient(
+            "codex",
+            cwd="/tmp",
+            env_factory=lambda: {
+                "PATH": "/usr/bin",
+                "CODEX_HOME": str(self.codex_home),
+            },
+            process_factory=factory,
+            request_timeout=1,
+        )
+
+    def test_auth_file_path_follows_codex_home(self) -> None:
+        self.assertEqual(
+            codex_auth_file_path({"CODEX_HOME": str(self.codex_home)}),
+            str(self.auth_file),
+        )
+        self.assertEqual(
+            codex_auth_file_path({}),
+            os.path.join(os.path.expanduser("~"), ".codex", "auth.json"),
+        )
+        # An empty value must fall back rather than resolve against the cwd.
+        self.assertEqual(
+            codex_auth_file_path({"CODEX_HOME": "   "}),
+            os.path.join(os.path.expanduser("~"), ".codex", "auth.json"),
+        )
+
+    async def test_signing_in_again_retires_the_stale_process(self) -> None:
+        self.write_credentials("revoked-token")
+        factory = FakeProcessFactory()
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+        await client.start()
+        generation = client.generation
+
+        # The user signs in again out of band, exactly as `codex login` does.
+        self.write_credentials("freshly-issued-token-after-sign-in")
+
+        self.assertTrue(await client.retire_replaced_credentials())
+        self.assertFalse(client.ready)
+
+        # The lazy restart is what actually reads the new credentials, so the
+        # user never has to sign in a second time.
+        await client.start()
+        self.assertTrue(client.ready)
+        self.assertGreater(client.generation, generation)
+        self.assertEqual(len(factory.calls), 2)
+
+        # The replacement is current, so nothing retires it again.
+        self.assertFalse(await client.retire_replaced_credentials())
+        self.assertTrue(client.ready)
+
+    async def test_unchanged_credentials_keep_the_live_process(self) -> None:
+        self.write_credentials("still-valid-token")
+        factory = FakeProcessFactory()
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+        await client.start()
+
+        self.assertFalse(await client.retire_replaced_credentials())
+        self.assertTrue(client.ready)
+        self.assertEqual(len(factory.calls), 1)
+
+    async def test_first_sign_in_retires_a_process_started_without_credentials(
+        self,
+    ) -> None:
+        factory = FakeProcessFactory()
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+        await client.start()
+        self.assertFalse(self.auth_file.exists())
+
+        self.write_credentials("first-ever-token")
+
+        self.assertTrue(await client.retire_replaced_credentials())
+        self.assertFalse(client.ready)
+
+    async def test_unreadable_credentials_are_never_treated_as_a_change(
+        self,
+    ) -> None:
+        self.write_credentials("token")
+        factory = FakeProcessFactory()
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+        await client.start()
+
+        # A vanished file proves nothing about newer credentials existing, and
+        # must never cost the user a working process.
+        self.auth_file.unlink()
+
+        self.assertFalse(await client.retire_replaced_credentials())
+        self.assertTrue(client.ready)
+
+    async def test_in_flight_turns_are_never_killed_by_a_sign_in(self) -> None:
+        self.write_credentials("token")
+        factory = FakeProcessFactory()
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+        await client.start()
+
+        # The app-server is shared by every Codex thread, so a turn that is
+        # still running on a valid in-memory token must survive the sign-in.
+        client._turns_by_thread["thr_busy"] = object()
+        self.write_credentials("token-from-a-later-sign-in")
+
+        self.assertFalse(await client.retire_replaced_credentials())
+        self.assertTrue(client.ready)
+
+        client._turns_by_thread.clear()
+        self.assertTrue(await client.retire_replaced_credentials())
+        self.assertFalse(client.ready)
+
+    async def test_a_process_that_never_started_is_not_retired(self) -> None:
+        self.write_credentials("token")
+        factory = FakeProcessFactory()
+        client = self.make_client(factory)
+        self.addAsyncCleanup(client.close)
+
+        self.assertFalse(await client.retire_replaced_credentials())
+        self.assertEqual(len(factory.calls), 0)
+
+    async def test_manager_delegates_credential_retirement(self) -> None:
+        self.write_credentials("revoked")
+        factory = FakeProcessFactory()
+        manager = CodexAppServerManager(
+            "codex",
+            cwd="/tmp",
+            env_factory=lambda: {
+                "PATH": "/usr/bin",
+                "CODEX_HOME": str(self.codex_home),
+            },
+            process_factory=factory,
+            request_timeout=1,
+        )
+        self.addAsyncCleanup(manager.close)
+        await manager.start()
+
+        self.write_credentials("re-issued-after-sign-in")
+
+        self.assertTrue(await manager.retire_replaced_credentials())
+        self.assertFalse(manager.ready)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

Codex reads its rotating OAuth credentials from `auth.json` once per process. The `codex app-server` we supervise is long-lived, so a sign-in that happens *after* it started is invisible to it — it keeps refreshing the credentials it loaded at launch and fails every turn with:

> Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.

Signing in again does not clear it. That is what makes it a dead end: the credentials on disk are already correct, but nothing tells the running child to re-read them. The only escape was to kill the app-server or restart the server, and the error text actively points users away from both.

Observed live: app-server launched 12:25:17, user re-authenticated successfully at 13:42:27, and every message after that still failed with the same message.

## The fix

Record the credential file each process was launched against, and retire a generation whose credentials have since been replaced. The next lazy `start()` reads the new file, so a sign-in the user already completed just works on their next message — no restart, no second sign-in, nothing to notice.

- `codex_auth_file_path()` / `codex_auth_signature()` resolve `$CODEX_HOME/auth.json` and take an `(mtime_ns, size)` fingerprint.
- `start()` samples it before spawning and stores it on the client.
- `retire_replaced_credentials()` retires the generation when the fingerprint has moved, reusing the existing `retire_generation()`.
- `run_codex_app_server()` calls it once per turn, before the turn begins.

## Constraints this respects

- **The turn is never replayed.** This module does not replay requests whose delivery may have succeeded, and an auth failure is no reason to start.
- **Only an idle process is retired.** The app-server multiplexes every Codex thread, so discarding it mid-turn would kill work still running fine on a valid in-memory token.
- **An absent or unreadable `auth.json` is never treated as a change**, since it cannot prove newer credentials exist, and must not cost a working process.

The file is sampled before the spawn rather than after: a sign-in landing during startup then costs one redundant retire, where sampling afterwards could record credentials the child never read and strand the user on them.

## Tests

8 new tests in `CodexCredentialRetirementTests` covering the sign-in path, the unchanged-credentials path, first-ever sign-in, vanished file, in-flight turns, a never-started process, `CODEX_HOME` resolution, and the manager delegate.

`test_codex_app_server` + adjacent Codex suites: 229 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)