### PR TITLE
Fix beta.54 paired-grant rollback and release contract fixtures

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -7566,8 +7566,10 @@ async def persist_provider_cross_chat_pair_grants(
                 else:
                     routes[routes.index(current)] = route
                 changes_by_session[owner_id].append({
-                    "after": route,
-                    "before": dict(current) if current else None,
+                    # The journal is an immutable revision-CAS proof, not a
+                    # reference to a route that a later edit may mutate.
+                    "after": {**route, "actions": list(route["actions"])},
+                    "before": {**current, "actions": list(current["actions"])} if current else None,
                 })
         mutations: dict[str, dict[str, Any]] = {}
         previous: dict[str, dict[str, Any]] = {}
@@ -7916,8 +7918,22 @@ async def rollback_durable_provider_cross_chat_reference_grants(
                     reconcile_pending_provider_cross_chat_grant(
                         session_id, session, force_rollback=True,
                     )
-            await STORE.persist_restored_state(durable=True)
-        return
+            rollback_error: BaseException | None = None
+            for _attempt in range(3):
+                try:
+                    await STORE.persist_restored_state(durable=True)
+                    return
+                except BaseException as exc:
+                    rollback_error = exc
+            # Keep every participant narrowed even if persistence remains
+            # unavailable; never re-expose an unaccepted grant on failure.
+            logger.critical(
+                "durable paired cross-chat admission rollback could not be persisted "
+                "source=%s",
+                source_session_id,
+            )
+            assert rollback_error is not None
+            raise rollback_error
     async with STORE._lock:
         source = STORE.sessions.get(source_session_id)
         if source is None:

--- a/docs/RELEASE_0.1.26-beta.54.md
+++ b/docs/RELEASE_0.1.26-beta.54.md
@@ -31,6 +31,16 @@ candidate, plus the exact paging fixture executed with AST-extracted
 compiled without imports; shell syntax and whitespace checks passed. No
 monolithic server, live provider, production state, or listener was started.
 
+The initial full gate (run `34501473187`) found two paired-grant rollback
+regressions and seven stale contract fixtures; publication did not run. Pair
+journals now retain detached revision-CAS snapshots, and rollback retries
+durable persistence without restoring unaccepted authority. Follow-up checks
+passed 104 guarded regressions (including repeated cancellation), the four
+exact legacy cross-chat cases via AST extraction, and 36 focused Mail/CLI/schema
+checks. Fixtures assert the reciprocal pair proof, supported Mail title and
+projection behavior, bounded expiry scan, and exact schema 19. A fresh full
+workflow gate is still required before publication.
+
 Local validation and release acceptance are separate. The signed release
 workflow must pass its full gate before publication. Deploy with the managed
 beta updater's `when_idle` reservation and exact server identity; never use a

--- a/test_agent_cross_chat_routes.py
+++ b/test_agent_cross_chat_routes.py
@@ -442,7 +442,7 @@ class AgentCrossChatRouteTests(unittest.IsolatedAsyncioTestCase):
             [],
         )
 
-    async def test_durable_grant_upsert_is_idempotent_and_directional(self) -> None:
+    async def test_durable_grant_upsert_is_idempotent_and_paired(self) -> None:
         reference = self.grant_reference()
         with (
             self.native_transports(),
@@ -486,14 +486,19 @@ class AgentCrossChatRouteTests(unittest.IsolatedAsyncioTestCase):
         ]
         self.assertEqual(len(routes), 1)
         self.assertEqual(routes[0]["actions"], ["instruction", "request_reply"])
-        self.assertEqual(
-            agent_server.STORE.sessions["target"]["provider_cross_chat_routes"],
-            [],
-        )
-        self.assertNotIn(
-            agent_server.PENDING_PROVIDER_CROSS_CHAT_GRANT_KEY,
-            agent_server.STORE.sessions["source"],
-        )
+        reverse_routes = agent_server.STORE.sessions["target"]["provider_cross_chat_routes"]
+        self.assertEqual(len(reverse_routes), 1)
+        self.assertEqual(reverse_routes[0]["actions"], ["instruction", "request_reply"])
+        self.assertEqual(routes[0]["target_session_id"], "target")
+        self.assertEqual(reverse_routes[0]["target_session_id"], "source")
+        self.assertEqual(routes[0]["pair_id"], reverse_routes[0]["pair_id"])
+        self.assertEqual(routes[0]["paired_route_id"], reverse_routes[0]["route_id"])
+        self.assertEqual(reverse_routes[0]["paired_route_id"], routes[0]["route_id"])
+        for session_id in ("source", "target"):
+            self.assertNotIn(
+                agent_server.PENDING_PROVIDER_CROSS_CHAT_GRANT_KEY,
+                agent_server.STORE.sessions[session_id],
+            )
 
     async def test_pending_grant_restart_reconciles_exact_admission_event(
         self,
@@ -539,6 +544,7 @@ class AgentCrossChatRouteTests(unittest.IsolatedAsyncioTestCase):
                         "session_id": "source",
                         "type": "turn_started",
                         "provider_cross_chat_grant_admission_id": admission_id,
+                        "provider_cross_chat_route_snapshot": mutation["routes"],
                     }) + "\n", encoding="utf-8")
                 recovered = agent_server.SessionStore()
                 with (
@@ -573,6 +579,7 @@ class AgentCrossChatRouteTests(unittest.IsolatedAsyncioTestCase):
             "session_id": "source",
             "type": "turn_started",
             "provider_cross_chat_grant_admission_id": admission_id,
+            "provider_cross_chat_route_snapshot": mutation["routes"],
         }) + "\n", encoding="utf-8")
         recovered = agent_server.SessionStore()
         with (
@@ -794,10 +801,11 @@ class AgentCrossChatRouteTests(unittest.IsolatedAsyncioTestCase):
                 mutation,
             )
         self.assertEqual(save.await_count, 3)
-        self.assertEqual(
-            agent_server.STORE.sessions["source"]["provider_cross_chat_routes"],
-            [],
-        )
+        for session_id in ("source", "target"):
+            session = agent_server.STORE.sessions[session_id]
+            self.assertEqual(session["provider_cross_chat_routes"], [])
+            self.assertEqual(session["provider_cross_chat_route_audit"], [])
+            self.assertNotIn(agent_server.PENDING_PROVIDER_CROSS_CHAT_GRANT_KEY, session)
 
     async def test_durable_session_save_fsyncs_file_rename_and_directory(
         self,

--- a/test_agentsdock_team.py
+++ b/test_agentsdock_team.py
@@ -718,20 +718,39 @@ class AgentsDockTeamCLITests(unittest.TestCase):
                 2,
             )
 
-    def test_send_rejects_title_for_plain_message(self) -> None:
+    def test_send_accepts_title_for_plain_message(self) -> None:
+        route_id = "team_" + "b" * 32
         with (
             patch.dict(agentsdock_team.os.environ, {"AGENTSDOCK_SERVER_URL": "http://127.0.0.1:7850"}),
             patch.object(agentsdock_team.sys, "stdin", io.StringIO("body")),
             patch.object(agentsdock_team.urllib.request, "build_opener") as opener,
         ):
+            opener.return_value.open.return_value = FakeResponse({
+                "ok": True,
+                "route_id": route_id,
+                "message_id": "tmsg_subject_1",
+                "kind": "message",
+                "accepted": True,
+                "duplicate": False,
+                "attachments": 0,
+            })
             self.assertEqual(
                 agentsdock_team.main([
                     "--authority-file", self.authority(), "send",
-                    "--route", "team_" + "b" * 32, "--title", "Unexpected",
+                    "--route", route_id, "--title", "  Build update  ",
                 ]),
-                2,
+                0,
             )
-        opener.assert_not_called()
+        opener.assert_called_once()
+        opener.return_value.open.assert_called_once()
+        request = opener.return_value.open.call_args.args[0]
+        self.assertEqual(request.method, "POST")
+        self.assertEqual(request.full_url, f"http://127.0.0.1:7850/api/agent/team/routes/{route_id}")
+        payload = json.loads(request.data.decode("utf-8"))
+        self.assertEqual(payload["title"], "Build update")
+        self.assertEqual(payload["kind"], "message")
+        self.assertEqual(payload["body"], "body")
+        self.assertNotIn("skill", payload)
 
 
 class ProviderTeamEndpointTests(unittest.IsolatedAsyncioTestCase):
@@ -894,7 +913,8 @@ class ProviderTeamEndpointTests(unittest.IsolatedAsyncioTestCase):
                 self.request(), box="inbox", unread=True, limit=500
             )
         listed.assert_called_once_with(
-            box="inbox", team_id=None, unread=True, since=None, after_sequence=0, limit=100
+            box="inbox", team_id=None, unread=True, since=None, after_sequence=0, limit=100,
+            include_mail_subject=False,
         )
         self.assertIn("team-authored", result["notice"])
         with self.assertRaises(HTTPException) as raised:

--- a/test_provider_chat_pairs_isolated.py
+++ b/test_provider_chat_pairs_isolated.py
@@ -42,6 +42,7 @@ FUNCTIONS = {
     "async_route_queue_fields", "public_queued_turn", "queued_turn_from_event", "queued_turn_run_metadata",
     "sanitized_provider_route_label", "enqueue_turn",
     "provider_cross_chat_reciprocal_admission_fields",
+    "join_task_despite_caller_cancellation",
 }
 CONSTANTS = {
     "PROVIDER_CROSS_CHAT_ROUTE_ID_RE", "PROVIDER_CROSS_CHAT_ROUTE_REVISION_RE",
@@ -220,6 +221,82 @@ class ChatPairTests(unittest.IsolatedAsyncioTestCase):
         await self.call("rollback_durable_provider_cross_chat_reference_grants", "a", mutation)
         self.assertEqual(self.store.sessions, before)
         self.assertEqual(len(self.store.saved), 2)
+
+    async def test_staged_pair_journal_is_detached_from_later_route_revision(self):
+        mutation = await self.stage()
+        source = self.store.sessions["a"]
+        route = source["provider_cross_chat_routes"][0]
+        pending_after = source[self.pending_key]["rollback_changes"][0]["after"]
+        original_after = deepcopy(pending_after)
+        self.assertIsNot(pending_after, route)
+        self.assertIsNot(pending_after["actions"], route["actions"])
+        route["revision"] = "rev_" + "f" * 32
+        route["actions"].remove("request_reply")
+        self.assertEqual(pending_after, original_after)
+        await self.call("rollback_durable_provider_cross_chat_reference_grants", "a", mutation)
+        retained = source["provider_cross_chat_routes"][0]
+        self.assertEqual(retained["revision"], "rev_" + "f" * 32)
+        self.assertEqual(retained["actions"], ["instruction"])
+        self.assertEqual(len(source["provider_cross_chat_route_audit"]), 1)
+        self.assertEqual(self.routes("b"), [])
+        self.assertEqual(self.store.sessions["b"]["provider_cross_chat_route_audit"], [])
+        self.assertIsNone(self.call("live_provider_cross_chat_route", "a", retained))
+
+    async def test_pair_rollback_retries_transient_persistence_without_restoring_authority(self):
+        before = deepcopy(self.store.sessions)
+        mutation = await self.stage(targets=("b", "c"))
+        self.store.failure = OSError("transient rollback failure")
+        await self.call("rollback_durable_provider_cross_chat_reference_grants", "a", mutation)
+        self.assertEqual(self.store.sessions, before)
+        self.assertEqual(len(self.store.saved), 3)
+        self.assertEqual(self.store.saved[1:], [before, before])
+
+    async def test_pair_rollback_persistent_failure_stays_narrowed_and_raises_after_three_attempts(self):
+        before = deepcopy(self.store.sessions)
+        mutation = await self.stage(targets=("b", "c"))
+        failure = OSError("persistent rollback failure")
+        self.store.persist_restored_state = AsyncMock(side_effect=failure)
+        with self.assertRaises(OSError) as raised:
+            await self.call("rollback_durable_provider_cross_chat_reference_grants", "a", mutation)
+        self.assertIs(raised.exception, failure)
+        self.assertEqual(self.store.persist_restored_state.await_count, 3)
+        self.assertTrue(all(call.kwargs == {"durable": True}
+                            for call in self.store.persist_restored_state.await_args_list))
+        self.assertEqual(self.store.sessions, before)
+
+    async def test_pair_rollback_joins_durable_writer_despite_repeated_cancellation(self):
+        before = deepcopy(self.store.sessions)
+        mutation = await self.stage(targets=("b", "c"))
+        store_node = next(node for node in TREE.body if isinstance(node, ast.ClassDef) and node.name == "SessionStore")
+        persist_node = deepcopy(next(node for node in store_node.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "persist_restored_state"))
+        exec(compile(ast.fix_missing_locations(ast.Module(body=[persist_node], type_ignores=[])), "<isolated-rollback-persistence>", "exec"), self.namespace)
+        self.store.persist_restored_state = self.namespace["persist_restored_state"].__get__(self.store)
+        writer_started = asyncio.Event()
+        writer_release = asyncio.Event()
+        committed = []
+
+        async def blocked_save(*, durable):
+            self.assertTrue(durable)
+            writer_started.set()
+            await writer_release.wait()
+            committed.append(deepcopy(self.store.sessions))
+
+        self.store.save = AsyncMock(side_effect=blocked_save)
+        rollback = asyncio.create_task(self.call("rollback_durable_provider_cross_chat_reference_grants", "a", mutation))
+        try:
+            await asyncio.wait_for(writer_started.wait(), 1)
+            for _ in range(2):
+                rollback.cancel()
+                await asyncio.sleep(0)
+                self.assertFalse(rollback.done())
+                self.assertTrue(self.store._lock.locked())
+                self.assertEqual(self.store.sessions, before)
+        finally:
+            writer_release.set()
+            await asyncio.wait_for(rollback, 1)
+        self.assertEqual(committed, [before])
+        self.assertEqual(self.store.save.await_count, 1)
+        self.assertFalse(self.store._lock.locked())
 
     async def test_restart_accepts_both_directions_from_exact_source_event(self):
         mutation = await self.stage(event_type="turn_queued")

--- a/test_secure_peer_runtime.py
+++ b/test_secure_peer_runtime.py
@@ -4123,6 +4123,11 @@ class SecurePeerRuntimeTests(unittest.TestCase):
                 ) as expire,
                 mock.patch.object(
                     runtime.client,
+                    "list_auto_completion_candidates",
+                    wraps=runtime.client.list_auto_completion_candidates,
+                ) as candidates,
+                mock.patch.object(
+                    runtime.client,
                     "recover_pairing_attempts",
                     return_value={"remaining": 0},
                 ),
@@ -4133,7 +4138,10 @@ class SecurePeerRuntimeTests(unittest.TestCase):
                 ),
             ):
                 result = runtime.maintenance_once()
-            expire.assert_called_once_with()
+            # Maintenance expires pending work directly, then the bounded
+            # automatic-completion scan expires again before choosing work.
+            self.assertEqual(expire.call_args_list, [mock.call(), mock.call()])
+            candidates.assert_called_once_with(limit=1)
             self.assertFalse(result["active"])
             runtime.shutdown()
 

--- a/test_team_hub_foundation.py
+++ b/test_team_hub_foundation.py
@@ -51,7 +51,7 @@ class DatabaseTests(unittest.TestCase):
         connection = open_database()
         self.addCleanup(connection.close)
 
-        self.assertEqual(LATEST_SCHEMA_VERSION, 17)
+        self.assertEqual(LATEST_SCHEMA_VERSION, 19)
         self.assertEqual(
             connection.execute("PRAGMA user_version").fetchone()[0],
             LATEST_SCHEMA_VERSION,

--- a/test_team_mail_subject_routes.py
+++ b/test_team_mail_subject_routes.py
@@ -1,6 +1,7 @@
 """Mail-subject query forwarding with ASGI/mocked transports and isolated state."""
 
 import ast
+from contextlib import contextmanager
 from pathlib import Path
 import tempfile
 import threading
@@ -187,14 +188,15 @@ class MailSubjectPeerRoutesTests(unittest.TestCase):
 def isolated_runtime():
     tree = ast.parse((REPO / "secure_peer_runtime.py").read_text())
     source = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "SecurePeerRuntime")
-    names = {"_team_host_call", "_team_hub_get", "team_list_messages", "team_get_message", "team_send_message"}
+    names = {"_team_host_call", "_team_host_call_admitted", "_host_store_operation", "_team_hub_get", "team_list_messages", "team_get_message", "team_send_message"}
     selected = ast.ClassDef(name="Runtime", bases=[], keywords=[], decorator_list=[], body=[
         node for node in source.body if isinstance(node, ast.FunctionDef) and node.name in names
     ])
     module = ast.Module(body=[
         ast.ImportFrom(module="__future__", names=[ast.alias(name="annotations")], level=0), selected,
     ], type_ignores=[])
-    namespace = {"quote": quote, "urlencode": urlencode, "SecurePeerError": SecurePeerError, "Mapping": Mapping, "Path": Path}
+    namespace = {"quote": quote, "urlencode": urlencode, "SecurePeerError": SecurePeerError, "Mapping": Mapping, "Path": Path,
+        "contextmanager": contextmanager, "HubStore": HubStore}
     exec(compile(ast.fix_missing_locations(module), "<isolated-mail-subject-runtime>", "exec"), namespace)
     return namespace["Runtime"]
 
@@ -203,7 +205,13 @@ class MailSubjectRuntimeRoutesTests(unittest.TestCase):
     def setUp(self):
         self.runtime = isolated_runtime()()
         self.runtime._guard = threading.RLock()
+        self.runtime._peer_admission = threading.Condition(threading.RLock())
+        self.runtime._host_admission_closed = False
+        self.runtime._host_in_flight = 0
+        self.runtime._host_operation_state = threading.local()
+        self.runtime._completion_closing = False
         self.store = mock.Mock(hub_id="subject-hub-001")
+        self.store.maintenance_fence.return_value = None
         self.runtime._hub_store = self.store
         self.runtime.team_realm = mock.Mock()
         self.runtime.proxy = mock.Mock(return_value={"ok": True})
@@ -242,6 +250,8 @@ class MailSubjectRuntimeRoutesTests(unittest.TestCase):
             self.assertIs(method.call_args.kwargs["include_mail_subject"], False)
             operation(include_mail_subject=True)
             self.assertIs(method.call_args.kwargs["include_mail_subject"], True)
+        self.assertEqual(self.runtime._host_in_flight, 0)
+        self.assertEqual(self.store.maintenance_fence.call_count, 4)
         self.runtime.proxy.assert_not_called()
 
     def send(self, **payload):


### PR DESCRIPTION
Correct two real defects caught before beta.54 publication: detach pair rollback CAS snapshots from mutable live routes, and restore cancellation-safe durable cleanup retries. Add regressions for newer revisions, transient/permanent save failures and repeated cancellation. Align legacy fixtures with reciprocal pairs, Mail subjects, host admission and schema19. No migration changes, Mail stream enablement, research-job changes or deployment. This remains the same unpublished beta.54; the prior workflow stopped before packaging/tagging.