### PR TITLE
Fix beta.61 mailbox entry points and release validation

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -71800,6 +71800,8 @@ def is_team_hub_server_session_route_allowed(method: str, path: str) -> bool:
 AGENT_HELPER_ROUTE_RULES: tuple[tuple[str, re.Pattern[str], int], ...] = (
     ("POST", re.compile(r"^/api/agent/cross-chat/handoffs$"), 2 * 1024 * 1024),
     ("GET", re.compile(r"^/api/agent/cross-chat/routes$"), 0),
+    ("GET", re.compile(r"^/api/agent/cross-chat/inbox$"), 0),
+    ("POST", re.compile(r"^/api/agent/cross-chat/inbox/read$"), 16 * 1024),
     (
         "POST",
         re.compile(r"^/api/agent/cross-chat/routes/route_[0-9a-f]{32}/handoffs$"),

--- a/test_async_queued_message_controls_isolated.py
+++ b/test_async_queued_message_controls_isolated.py
@@ -18,6 +18,8 @@ from types import SimpleNamespace
 import unittest
 from unittest.mock import AsyncMock, Mock
 
+import chat_mailbox
+
 from test_async_route_transport_isolated import HTTPException, envelope, PAIR
 
 
@@ -44,6 +46,7 @@ def namespace():
     ns = {
         "asyncio": asyncio, "deque": deque, "contextmanager": contextmanager, "suppress": suppress,
         "hashlib": hashlib, "sqlite3": sqlite3, "threading": threading, "time": time,
+        "chat_mailbox": chat_mailbox,
         "HTTPException": HTTPException, "now_iso": lambda: "2026-09-10T20:00:00Z",
         "PROVIDER_CROSS_CHAT_LEGACY_RATE_RETENTION_SECONDS": 3600,
         "PROVIDER_CROSS_CHAT_ROUTE_PAIR_ID_RE": re.compile(r"pair_[0-9a-f]{32}"),

--- a/test_chat_mailbox_runtime_isolated.py
+++ b/test_chat_mailbox_runtime_isolated.py
@@ -76,6 +76,25 @@ def isolated_source():
 
 
 class ChatMailboxRuntimeTests(unittest.IsolatedAsyncioTestCase):
+    def test_mailbox_routes_have_exact_bounded_provider_header_entry_points(self):
+        names = {"agent_helper_route_body_limit", "is_agent_helper_route"}
+        nodes = [ast.ImportFrom(module="__future__", names=[ast.alias(name="annotations")], level=0)]
+        nodes.extend(deepcopy(node) for node in TREE.body if
+            isinstance(node, ast.FunctionDef) and node.name in names or
+            isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+            and node.target.id == "AGENT_HELPER_ROUTE_RULES")
+        namespace = {"re": re}
+        exec(compile(ast.fix_missing_locations(ast.Module(body=nodes, type_ignores=[])),
+                     "<isolated-mailbox-entry-points>", "exec"), namespace)
+        limit = namespace["agent_helper_route_body_limit"]
+        self.assertEqual(limit("GET", "/api/agent/cross-chat/inbox"), 0)
+        self.assertEqual(limit("POST", "/api/agent/cross-chat/inbox/read"), 16 * 1024)
+        for method, path in (("POST", "/api/agent/cross-chat/inbox"),
+                             ("GET", "/api/agent/cross-chat/inbox/read"),
+                             ("POST", "/api/agent/cross-chat/inbox/read/extra"),
+                             ("POST", "/api/agent/cross-chat/future")):
+            self.assertIsNone(limit(method, path))
+
     async def asyncSetUp(self):
         self.ns = isolated_source()
         temporary = tempfile.TemporaryDirectory(prefix="isolated-mailbox-")

--- a/test_chat_reference_mentions.py
+++ b/test_chat_reference_mentions.py
@@ -603,6 +603,9 @@ class ChatReferenceMentionTests(unittest.IsolatedAsyncioTestCase):
         submit = AsyncMock()
         update = AsyncMock(side_effect=[failed, running])
         with (
+            patch.object(agent_server, "CHAT_MAILBOX_PENDING", set()),
+            patch.object(agent_server.CROSS_CHAT, "mailbox_call", AsyncMock(return_value=[])),
+            patch.object(agent_server.CROSS_CHAT, "mailbox_envelopes", AsyncMock(return_value=[])),
             patch.object(agent_server.CROSS_CHAT, "pending_terminal_lifecycle", AsyncMock(return_value=[])),
             patch.object(agent_server.CROSS_CHAT, "recoverable", AsyncMock(return_value=[ready, running])),
             patch.object(agent_server.CROSS_CHAT, "update", update),

--- a/test_claude_history_provenance_isolated.py
+++ b/test_claude_history_provenance_isolated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 from collections import defaultdict, deque
 from datetime import datetime
 import io
@@ -12,11 +13,13 @@ import json
 from pathlib import Path
 import re
 import stat
+import tempfile
 from types import SimpleNamespace
 import unittest
 from unittest.mock import AsyncMock, Mock
 import uuid
 from claude_history_provenance import ClaudeInterruptionTracker, normalize_claude_interruption_context
+from codex_history_repair import CodexNativeHistoryRepairCache, filter_native_codex_history_items
 
 
 SOURCE = Path(__file__).with_name("agent_server.py")
@@ -74,7 +77,9 @@ def load_projection() -> dict:
         *selected,
     ], type_ignores=[]))
     namespace = {
-        "re": re, "datetime": datetime, "json": json, "uuid": uuid,
+        "re": re, "datetime": datetime, "json": json, "uuid": uuid, "asyncio": asyncio,
+        "filter_native_codex_history_items": filter_native_codex_history_items,
+        "CODEX_NATIVE_HISTORY_REPAIR_CACHE": CodexNativeHistoryRepairCache(),
         "hashlib": hashlib, "hmac": hmac, "deque": deque, "defaultdict": defaultdict,
         "ClaudeInterruptionTracker": ClaudeInterruptionTracker,
         "normalize_claude_interruption_context": normalize_claude_interruption_context,
@@ -356,6 +361,9 @@ class ClaudeHistoryProvenanceTests(unittest.TestCase):
 class ImportedHistoryProvenanceTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.projection = load_projection()
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.projection["events_path"] = lambda _session_id: Path(temporary.name) / "events.jsonl"
         self.session = {"id": "app-chat", "backend": "claude", "claude_session_id": SESSION_ID}
 
         async def durable(_session_id, specifications):

--- a/test_claude_sdk_runner.py
+++ b/test_claude_sdk_runner.py
@@ -8,7 +8,7 @@ import unittest
 from collections import OrderedDict, deque
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from unittest.mock import AsyncMock, Mock, patch
 
 from fastapi import HTTPException
@@ -196,6 +196,7 @@ class FakeClaudeManager:
         configuration_key: str,
         query_session_id: str | None = None,
         on_supervisor_ready: object | None = None,
+        pending_mail_hint: Callable[[], str | None] | None = None,
     ) -> FakeClaudeRun:
         self.start_calls.append(
             (
@@ -271,6 +272,7 @@ class FakeClaudeManagerFailingAfterOwnership(FakeClaudeManager):
         configuration_key: str,
         query_session_id: str | None = None,
         on_supervisor_ready: object | None = None,
+        pending_mail_hint: Callable[[], str | None] | None = None,
     ) -> FakeClaudeRun:
         self.start_calls.append(
             (chat_id, prompt, run_id, options, configuration_key, query_session_id)
@@ -296,6 +298,7 @@ class SequencedClaudeManager(FakeClaudeManager):
         configuration_key: str,
         query_session_id: str | None = None,
         on_supervisor_ready: object | None = None,
+        pending_mail_hint: Callable[[], str | None] | None = None,
     ) -> FakeClaudeRun:
         self.start_calls.append(
             (
@@ -342,6 +345,7 @@ class PermissionDuringStartManager(SequencedClaudeManager):
         configuration_key: str,
         query_session_id: str | None = None,
         on_supervisor_ready: object | None = None,
+        pending_mail_hint: Callable[[], str | None] | None = None,
     ) -> FakeClaudeRun:
         call_number = len(self.start_calls) + 1
         self.start_calls.append(
@@ -424,6 +428,7 @@ class BlockingCandidateStartManager(SequencedClaudeManager):
         configuration_key: str,
         query_session_id: str | None = None,
         on_supervisor_ready: object | None = None,
+        pending_mail_hint: Callable[[], str | None] | None = None,
     ) -> FakeClaudeRun:
         call_number = len(self.start_calls) + 1
         self.start_calls.append(
@@ -462,6 +467,7 @@ class SafeFailingCandidateStartManager(SequencedClaudeManager):
         configuration_key: str,
         query_session_id: str | None = None,
         on_supervisor_ready: object | None = None,
+        pending_mail_hint: Callable[[], str | None] | None = None,
     ) -> FakeClaudeRun:
         call_number = len(self.start_calls) + 1
         self.start_calls.append((

--- a/test_codex_native_turn_projection_isolated.py
+++ b/test_codex_native_turn_projection_isolated.py
@@ -24,6 +24,7 @@ _FUNCTIONS = {
     "codex_reasoning_text",
     "codex_app_server_reasoning_summary",
     "session_lifecycle_lock",
+    "maybe_notify_chat_mailbox_codex",
 }
 _TREE = ast.parse(_SOURCE.read_text(encoding="utf-8"), filename=str(_SOURCE))
 _SELECTED = [node for node in _TREE.body if isinstance(
@@ -96,6 +97,7 @@ class NativeTurnProjectionTests(unittest.IsolatedAsyncioTestCase):
             "suppress": suppress,
             "STORE": store, "ACTIVE_LOCK": asyncio.Lock(),
             "SESSION_LIFECYCLE_LOCKS": {},
+            "CHAT_MAILBOX_PENDING": set(),
             "ACTIVE": {"chat": {"run_id": "operation"}},
             "STOPPED_RUNS": {"unrelated"} | ({"operation"} if stopped or interrupted_before_start else set()),
             "BACKEND_CODEX": "codex",

--- a/test_installer.py
+++ b/test_installer.py
@@ -1398,7 +1398,7 @@ exit 0
         self.assertIsNotNone(release_files_match)
         release_files = release_files_match.group(1).split()
         for filename in (
-            "activation_transaction.py agent_server.py team_hub_host.py secure_peer_runtime.py secure_peer_delivery.py agentsdock_jobs.py agentsdock_chats.py agentsdock_emergency.py agentsdock_publish.py agentsdock_mail.py agentsdock_team.py provider_commands.py claude_sdk_client.py claude_background_reconciliation.py codex_app_server.py cursor_agent_client.py cursor_process_guard.py"
+            "activation_transaction.py agent_server.py team_hub_host.py secure_peer_runtime.py secure_peer_delivery.py agentsdock_jobs.py agentsdock_chats.py chat_mailbox.py agentsdock_emergency.py agentsdock_publish.py agentsdock_mail.py agentsdock_team.py provider_commands.py claude_sdk_client.py claude_background_reconciliation.py codex_app_server.py cursor_agent_client.py cursor_process_guard.py"
         ).split():
             self.assertIn(filename, release_files)
         self.assertIn('"$STAGE_DIR/activation_transaction.py"', installer_source)
@@ -1416,9 +1416,10 @@ exit 0
             installer_source,
         )
         self.assertIn(
-            "agentsdock_team, provider_commands, claude_history_repair",
+            "agentsdock_team, claude_history_repair",
             installer_source,
         )
+        self.assertIn("chat_mailbox, provider_commands;", installer_source)
         self.assertIn('"$STAGE_DIR/secure_peer_runtime.py"', installer_source)
         self.assertIn('"$STAGE_DIR/secure_peer_delivery.py"', installer_source)
         self.assertIn('"$STAGE_DIR/uninstall.sh"', installer_source)

--- a/test_provider_chat_pairs_isolated.py
+++ b/test_provider_chat_pairs_isolated.py
@@ -493,7 +493,9 @@ class ChatPairTests(unittest.IsolatedAsyncioTestCase):
         message = self.delivery(route)
         await self.call("delete_agent_handoff_route", "a", route["route_id"], route["revision"])
         self.retired.reset_mock()
+        self.namespace["CHAT_MAILBOX_PENDING"] = set()
         self.namespace["CROSS_CHAT"] = SimpleNamespace(
+            mailbox_call=AsyncMock(return_value=[]), mailbox_envelopes=AsyncMock(return_value=[]),
             pending_terminal_lifecycle=AsyncMock(return_value=[]), recoverable=AsyncMock(return_value=[message]),
             get_exchange_leg=AsyncMock(return_value={"id": "leg", "exchange_id": "exchange", "kind": "request", "status": "queued"}),
             get_exchange=AsyncMock(return_value={"id": "exchange", "authorization_kind": "configured_route",
@@ -619,7 +621,7 @@ class ChatPairTests(unittest.IsolatedAsyncioTestCase):
             file_ids=[], chat_references=[], team_references=[], source_session_id="a", target_session_id="b",
             cross_chat_envelope_id="message", cross_chat_exchange_id=None, cross_chat_exchange_leg_id=None,
             cross_chat_exchange_status=False, secure_peer_envelope_id=None, backend=None, model=None, effort=None,
-            digest_job_id=None, digest_detail=None, client_capabilities=["backend-exact"],
+            digest_job_id=None, digest_detail=None, client_capabilities=["backend-exact"], skill_selection=None,
         )
         result = await self.call("enqueue_turn", "b", request, self.store.sessions["b"], provider_route_snapshot=self.routes("b"))
         self.assertTrue(result["queued"])


### PR DESCRIPTION
Register exact authenticated provider mailbox list/read entry points with bounded request sizes; handlers retain current-run and route authorization. Align isolated and legacy test fixtures with the new mailbox state and callback signature, retaining existing ownership, cancellation, event-order and privacy assertions. No desktop or deployment changes. Targeted checks pass; rerun the full signed-release gate before beta.61 publication.