### PR TITLE
Preserve runtime provenance for Codex history notices

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -5097,7 +5097,7 @@ ARTIFACT_PUBLICATION_LOCK_STRIPES = tuple(asyncio.Lock() for _ in range(64))
 TIMELINE_PIN_LOCK_STRIPES = tuple(asyncio.Lock() for _ in range(64))
 TIMELINE_INDEX_CACHE_MAX = int(agentsdock_setting("TIMELINE_INDEX_CACHE_MAX", "24"))
 TIMELINE_INDEX_CACHE: OrderedDict[str, dict[str, Any]] = OrderedDict()
-TIMELINE_INDEX_PROJECTION_VERSION = 5
+TIMELINE_INDEX_PROJECTION_VERSION = 6
 # Retained as a compatibility/testing surface; synchronization uses the fixed
 # stripe pool below so deleted-session churn cannot leak one lock per chat.
 TIMELINE_INDEX_LOCKS: dict[str, threading.Lock] = {}
@@ -5112,7 +5112,7 @@ FORK_INTERNAL_RUN_CACHE: OrderedDict[str, dict[str, Any]] = OrderedDict()
 FORK_INTERNAL_RUN_LOCKS: dict[str, threading.Lock] = {}
 HISTORY_SEARCH_DB = STATE_DIR / "history_search.sqlite3"
 HISTORY_SEARCH_LOCK = threading.Lock()
-HISTORY_SEARCH_INDEX_VERSION = "7"
+HISTORY_SEARCH_INDEX_VERSION = "8"
 HISTORY_SEARCH_DIRTY: set[str] = set()
 HISTORY_SEARCH_REPAIR_DIRTY: set[str] = set()
 HISTORY_SEARCH_SYNC_INTERVAL_SECONDS = max(
@@ -46040,6 +46040,38 @@ def codex_history_user_record(event: dict[str, Any]) -> tuple[dict[str, Any], st
     return None
 
 
+def codex_runtime_user_item_kind(item: dict[str, Any], text: str) -> str | None:
+    """Two explicitly typed provider inputs, never a text-only quotation filter."""
+    if item.get("type") != "message" or item.get("role") != "user" or codex_user_item_has_human_provenance(item):
+        return None
+    metadata = item.get("internal_chat_message_metadata_passthrough")
+    kinds = metadata.get("content_item_kinds") if isinstance(metadata, dict) else None
+    if not isinstance(kinds, list) or not kinds:
+        return None
+    if all(kind == "generic.turn_aborted" for kind in kinds):
+        match = re.fullmatch(r"<turn_aborted>\s*([\s\S]*?)\s*</turn_aborted>", str(text or "").strip())
+        return "turn_aborted" if match is not None and match.group(1).strip() else None
+    if any(kind != "multi_agent.subagent_notification" for kind in kinds):
+        return None
+    match = re.fullmatch(r"<subagent_notification>\s*([\s\S]*?)\s*</subagent_notification>", str(text or "").strip())
+    if match is None:
+        return None
+    try:
+        notification = json.loads(match.group(1))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(notification, dict) or set(notification) != {"agent_path", "status"}:
+        return None
+    path, status = notification["agent_path"], notification["status"]
+    return "subagent_notification" if (isinstance(path, str) and 0 < len(path.strip()) <= 256
+            and isinstance(status, dict) and set(status) == {"completed"}
+            and isinstance(status["completed"], str)) else None
+
+
+def is_codex_subagent_notification_user_item(item: dict[str, Any], text: str) -> bool:
+    return codex_runtime_user_item_kind(item, text) == "subagent_notification"
+
+
 def codex_history_user_item(
     payload: dict[str, Any],
     text: str,
@@ -46109,6 +46141,12 @@ def codex_history_user_event_item(
         item.update(codex_history_assistant_metadata({"ts": event.get("timestamp")}))
         origin = codex_public_item_origin(event)
         if origin is not None:
+            runtime_kind = codex_runtime_user_item_kind(payload, text)
+            if (runtime_kind is not None
+                    and item.get("text") == text.strip() and item.get("source_text_sha256") is None):
+                origin = {**origin, "kind": runtime_kind,
+                    "source_text_sha256": hashlib.sha256(item["text"].encode("utf-8", errors="surrogatepass")).hexdigest()}
+                item["provider_runtime_context"] = runtime_kind
             item["provider_origin"] = origin
     return item
 
@@ -46116,6 +46154,8 @@ def codex_history_user_event_item(
 def merge_codex_history_duplicate(previous: dict[str, Any], item: dict[str, Any]) -> bool:
     """Enrich a retained duplicate, but never collapse known distinct phases."""
     old_origin, new_origin = previous.get("provider_origin"), item.get("provider_origin")
+    if previous.get("provider_runtime_context") != item.get("provider_runtime_context"):
+        return False
     if isinstance(old_origin, dict) and isinstance(new_origin, dict) and any(
         old_origin.get(key) != new_origin.get(key) for key in ("event_id", "turn_id")
     ):
@@ -46318,7 +46358,7 @@ def codex_transcript_preview(path: Path) -> str | None:
             if index >= CODEX_TRANSCRIPT_SCAN_LINES:
                 break
             item = codex_history_event_item(event)
-            if item is not None and item.get("kind") == "user":
+            if item is not None and item.get("kind") == "user" and item.get("provider_runtime_context") not in ("subagent_notification", "turn_aborted"):
                 return item["text"][:160]
     return None
 
@@ -46495,6 +46535,12 @@ def provider_history(sess: dict[str, Any], limit: int | None) -> tuple[Path | No
 
 def history_item_cursor_digest(item: dict[str, Any]) -> str:
     identity = [str(item.get("kind") or ""), str(item.get("text") or "").strip()]
+    runtime_origin = item.get("provider_origin")
+    if (item.get("kind") == "user" and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted")
+        and item.get("provider_user_authored") is not True and isinstance(runtime_origin, dict)
+        and runtime_origin.get("provider") == "codex" and runtime_origin.get("kind") == item["provider_runtime_context"]
+        and all(isinstance(runtime_origin.get(key), str) and runtime_origin[key] for key in ("event_id", "turn_id"))):
+        identity = [item["provider_runtime_context"], runtime_origin["event_id"], runtime_origin["turn_id"], identity[1]]
     if item.get("kind") == "interruption":
         origin = normalized_history_provider_origin(item.get("provider_origin"))
         if origin is not None and origin.get("kind") == "interruption":
@@ -47856,6 +47902,12 @@ async def append_imported_history(
             if backend == BACKEND_CODEX and isinstance(item.get("provider_origin"), dict) and item["provider_origin"].get("provider") == "codex" else None
         )
         provenance: dict[str, Any] = {"provider_origin": origin} if origin is not None else {}
+        runtime_notification = (backend == BACKEND_CODEX and item.get("kind") == "user"
+            and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted")
+            and item.get("provider_user_authored") is not True and origin is not None
+            and origin.get("kind") == item["provider_runtime_context"])
+        if runtime_notification:
+            provenance.update(metadata_only=True, provider_runtime_context=item["provider_runtime_context"])
         if backend == BACKEND_CODEX and item.get("provider_history_repair") == "source_proven_native_replay" and item.get("text") == "":
             provenance.update(metadata_only=True, provider_history_repair="source_proven_native_replay")
         source_sha256 = item.get("source_text_sha256")
@@ -47875,7 +47927,7 @@ async def append_imported_history(
             imported_events.append(("turn_started", {
                 "run_id": run_id,
                 "backend": backend,
-                "prompt": item["text"],
+                "prompt": "" if runtime_notification else item["text"],
                 "imported": True,
                 "provider_history_sanitized": True,
                 **provenance,
@@ -47965,6 +48017,12 @@ async def append_staged_imported_history(
             if backend == BACKEND_CODEX and isinstance(item.get("provider_origin"), dict) and item["provider_origin"].get("provider") == "codex" else None
         )
         provenance: dict[str, Any] = {"provider_origin": origin} if origin is not None else {}
+        runtime_notification = (backend == BACKEND_CODEX and item.get("kind") == "user"
+            and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted")
+            and item.get("provider_user_authored") is not True and origin is not None
+            and origin.get("kind") == item["provider_runtime_context"])
+        if runtime_notification:
+            provenance.update(metadata_only=True, provider_runtime_context=item["provider_runtime_context"])
         source_sha256 = item.get("source_text_sha256")
         if isinstance(source_sha256, str) and re.fullmatch(r"[0-9a-f]{64}", source_sha256):
             provenance["source_text_sha256"] = source_sha256
@@ -47982,7 +48040,7 @@ async def append_staged_imported_history(
             imported_events.append(("turn_started", {
                 "run_id": run_id,
                 "backend": backend,
-                "prompt": item["text"],
+                "prompt": "" if runtime_notification else item["text"],
                 "imported": True,
                 "provider_history_sanitized": True,
                 **provenance,

--- a/codex_history_repair.py
+++ b/codex_history_repair.py
@@ -1,4 +1,4 @@
-"""Read-only, checkpoint-proven repair of legacy Codex goal-context imports.
+"""Read-only, checkpoint-proven repair of Codex runtime and native replay imports.
 
 Preparation is explicit, bounded and once per requested chat/provider. Event
 projection is memory-only. Missing, changing or ambiguous evidence stays visible.
@@ -25,6 +25,7 @@ from claude_history_repair import (
 MAX_PRIOR_SOURCE_PATHS = 2
 MAX_AGGREGATE_SOURCE_BYTES = 96 * 1024 * 1024
 MAX_AGGREGATE_SOURCE_RECORDS = 100_000
+MAX_FORK_META_HEADERS = 32
 _PROVIDER_ID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
 
 
@@ -328,6 +329,42 @@ def codex_public_item_origin(event: dict, provider_id: str | None = None) -> dic
     return origin
 
 
+def _runtime_human_provenance(event: dict) -> bool:
+    metadata = event.get("internal_chat_message_metadata_passthrough")
+    kinds = metadata.get("content_item_kinds") if isinstance(metadata, dict) else None
+    return event.get("provider_user_authored") is True or isinstance(kinds, list) and "user.text" in kinds or any(
+        isinstance(event.get(field), str) and event[field].strip()
+        for field in ("clientUserMessageId", "clientId", "client_user_message_id", "client_id")
+    ) or any(isinstance(origin, dict) and origin.get("kind") in ("human", "user", "user_input", "user-input")
+             for origin in (event.get("origin"), event.get("provider_origin")))
+
+
+def _persisted_runtime_marker(event: dict, session_id: str) -> bool:
+    origin = event.get("provider_origin")
+    runtime_kind = event.get("provider_runtime_context")
+    if (runtime_kind not in ("subagent_notification", "turn_aborted")
+        or event.get("metadata_only") is not True or event.get("backend") != "codex"
+        or event.get("imported") is not True or not isinstance(event.get("run_id"), str)
+        or not event["run_id"].startswith("import_") or event.get("session_id") != session_id
+        or not isinstance(event.get("id"), str) or not 0 < len(event["id"].strip()) <= 256
+        or type(event.get("seq")) is not int or event["seq"] <= 0
+        or event.get("type") != "turn_started" or event.get("prompt") != ""
+        or _runtime_human_provenance(event) or not isinstance(origin, dict)
+        or origin.get("provider") != "codex" or origin.get("kind") != runtime_kind
+        or not all(isinstance(origin.get(key), str) and 0 < len(origin[key].strip()) <= 256
+                   for key in ("event_id", "session_id", "turn_id"))
+        or not isinstance(origin.get("source_text_sha256"), str) or not _DIGEST.fullmatch(origin["source_text_sha256"])):
+        return False
+    timestamp = origin.get("timestamp")
+    if (not isinstance(timestamp, str) or timestamp != event.get("ts") or not re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)", timestamp)):
+        return False
+    try:
+        return datetime.fromisoformat(timestamp.replace("Z", "+00:00")).utcoffset() is not None
+    except ValueError:
+        return False
+
+
 def _replay_target(event: dict) -> tuple | None:
     kind = "user" if event.get("type") == "turn_started" else "assistant" if event.get("type") in ("assistant_text", "reasoning_summary") else None
     body = event.get("prompt") if kind == "user" else event.get("text")
@@ -342,7 +379,7 @@ def _replay_target(event: dict) -> tuple | None:
     # Human authorship does not make a duplicate a second human message.
     # Retain the original authorship flag; only this exact ledger copy is aliased.
     return (event["seq"], event["run_id"], event["id"], event["type"], kind, _text_key(body), event["ts"],
-            event.get("provider_user_authored") is True, event.get("source_text_sha256"))
+            _runtime_human_provenance(event), event.get("source_text_sha256"))
 
 
 @dataclass(frozen=True)
@@ -387,7 +424,7 @@ def _prove_native_replays(session_id: str, provider_id: str, events: Path, sourc
                 native.setdefault((run, kind, _text_key(body)), []).append(event)
         if len(candidates) + len(batches) + len(native) + len(owners) > MAX_KEYS:
             raise _Unproven()
-    if not candidates or not owners:
+    if not candidates:
         return _NativeProof(provider_id)
     groups = {}
     for run, batch in batches.items():
@@ -445,13 +482,29 @@ def _prove_native_source(thread: str, source: Path, root: Path, batches: dict, c
         return {}
     budget.reserve(stamp[2])
     digest, verified, canonical, occurrences = hashlib.sha256(), set(), {}, {}
+    allowed_header_owners, header_parents = {thread}, {}
     context_turn = None
     for record, offset, line in _records(source, stamp):
         budget.consume_record()
         payload = record.get("payload")
         if offset == len(line) or record.get("type") == "session_meta":
-            if record.get("type") != "session_meta" or not isinstance(payload, dict) or payload.get("id") != thread:
+            if record.get("type") != "session_meta" or not isinstance(payload, dict):
                 raise _Unproven()
+            owner, parent = payload.get("id"), payload.get("forked_from_id")
+            if (not isinstance(owner, str) or owner not in allowed_header_owners
+                or offset == len(line) and owner != thread
+                or parent is not None and (not isinstance(parent, str) or not _PROVIDER_ID.fullmatch(parent))
+                or owner in header_parents and header_parents[owner] != parent
+                or owner not in header_parents and parent in header_parents):
+                raise _Unproven()
+            # Forked rollouts retain an ancestral session_meta immediately
+            # after their own header. Only the declared parent chain is valid;
+            # an unrelated embedded owner cannot relabel this source file.
+            header_parents[owner] = parent
+            if len(header_parents) > MAX_FORK_META_HEADERS:
+                raise _Unproven()
+            if parent is not None:
+                allowed_header_owners.add(parent)
         digest.update(line)
         for expected in wanted.get(offset, ()):
             if hmac.compare_digest(digest.hexdigest(), expected):
@@ -464,6 +517,11 @@ def _prove_native_source(thread: str, source: Path, root: Path, batches: dict, c
         if not item or item.get("kind") not in ("user", "assistant") or not isinstance(item.get("text"), str):
             continue
         origin = codex_public_item_origin(record, thread)
+        runtime_kind = item.get("provider_runtime_context")
+        if (origin and runtime_kind in ("subagent_notification", "turn_aborted")
+                and item.get("provider_user_authored") is not True
+                and (item.get("provider_origin") or {}).get("kind") == runtime_kind):
+            origin = {**origin, "kind": runtime_kind}
         turn = origin["turn_id"] if origin else context_turn
         timestamp = record.get("timestamp")
         if not isinstance(turn, str) or not isinstance(timestamp, str):
@@ -488,9 +546,18 @@ def _prove_native_source(thread: str, source: Path, root: Path, batches: dict, c
             continue
         key = next(iter(matches))
         source_ids, owned_runs = canonical.get(key, {}), owners.get((thread, key[0]), set())
-        if len(source_ids) != 1 or len(owned_runs) != 1 or source_hash is not None:
+        if len(source_ids) != 1 or source_hash is not None:
             # Truncated source hashes need a separately retained native full-body
             # hash. Until one exists, the bounded preview cannot prove equality.
+            continue
+        source_origin = next(iter(source_ids.values()))
+        if source_origin.get("kind") in ("subagent_notification", "turn_aborted"):
+            if kind == "user" and not _human:
+                proofs[target] = {**source_origin, "source_text_sha256": body_key}
+                if len(proofs) > MAX_TARGETS:
+                    raise _Unproven()
+            continue
+        if len(owned_runs) != 1:
             continue
         native_matches = native.get((next(iter(owned_runs)), kind, body_key), [])
         native_matches = [event for event in native_matches if type(event.get("seq")) is int and event["seq"] < first and isinstance(event.get("id"), str)]
@@ -535,6 +602,8 @@ class CodexNativeHistoryRepairCache(CodexGoalHistoryRepairCache):
     def project_event(self, session_id: str, event: dict) -> dict | None:
         if event.get("session_id") not in (None, "", session_id):
             return None
+        if _persisted_runtime_marker(event, session_id):
+            return {**event, "_agentsdock_imported_prompt_hidden": True}
         if (event.get("provider_history_repair") == "source_proven_native_replay"
             and event.get("metadata_only") is True and event.get("backend") == "codex"
             and event.get("imported") is True and str(event.get("run_id") or "").startswith("import_")
@@ -551,6 +620,10 @@ class CodexNativeHistoryRepairCache(CodexGoalHistoryRepairCache):
         origin = proof.targets.get(target) if target else None
         if origin is None:
             return None
+        if origin.get("kind") in ("subagent_notification", "turn_aborted"):
+            return {**event, "prompt": "", "metadata_only": True,
+                    "provider_runtime_context": origin["kind"], "provider_origin": origin,
+                    "_agentsdock_imported_prompt_hidden": True}
         return {**event, "prompt" if event["type"] == "turn_started" else "text": "",
                 "metadata_only": True, "provider_history_repair": "source_proven_native_replay", "provider_origin": origin,
                 **({"_agentsdock_imported_prompt_hidden": True} if event["type"] == "turn_started" else {})}

--- a/docs/CODEX_HISTORY_METADATA.md
+++ b/docs/CODEX_HISTORY_METADATA.md
@@ -42,3 +42,20 @@ Validation uses `test_codex_history_metadata_isolated.py` and the existing Codex
 goal/Claude isolated suites. They compile explicitly allowlisted AST helpers,
 mock persistence or use temporary files, and never import/start the server or
 contact a provider.
+
+## Typed runtime inputs
+
+Provider user-role records explicitly typed `multi_agent.subagent_notification`
+or `generic.turn_aborted` are runtime metadata, not human input. Classification
+requires the exclusive provider kind, the complete matching wrapper, valid
+provider identity, and no positive human/client provenance. Ordinary quotations
+and unknown or mixed kinds remain visible. Silent imported boundaries preserve
+following answers without creating a new human message or changing live state.
+
+Older imported copies are projected only after checkpoint, source digest,
+message identity, original timestamp and complete text prove the same record.
+A forked transcript may contain its explicitly declared ancestor headers; an
+unrelated or ambiguous header fails proof. Original transcripts and stored
+events are not rewritten. The bounded repair cache is prepared on demand and
+does not add polling. Runtime cursor identities are distinct from human text,
+so a later identical human quotation cannot be consumed as a duplicate.

--- a/docs/RELEASE_0.1.26-beta.61.md
+++ b/docs/RELEASE_0.1.26-beta.61.md
@@ -19,6 +19,11 @@ published desktop beta.33 binary.
   native turn ownership, message identity, timestamp and full text prove the
   replay. Preserve original human messages and scheduled reports. Retain source
   identity on new imports and prevent known native messages becoming new input.
+- Keep explicitly typed Codex subagent notifications and interruption notices
+  out of user-message bubbles. Correct older imports only with exact native
+  source proof, including declared fork ancestry. Preserve genuine quotations,
+  original timestamps, answers and live lifecycle state; no transcript rewrite
+  or additional background polling is involved.
 - Retire exact run ownership and capability state when a terminal event cannot
   be saved. Do not claim successful persistence or automatically drain Claude's
   next queued turn from that failed completion. Storage exhaustion before

--- a/test_codex_goal_history_isolated.py
+++ b/test_codex_goal_history_isolated.py
@@ -25,6 +25,8 @@ FUNCTIONS = {
     "normalized_history_provider_origin", "normalized_history_item",
     "normalized_history_import_limit", "codex_user_item_has_human_provenance",
     "is_codex_goal_runtime_user_item", "codex_history_user_record",
+    "is_codex_subagent_notification_user_item",
+    "codex_runtime_user_item_kind",
     "codex_history_user_item", "codex_history_event_item", "append_codex_history_event",
     "codex_history_assistant_metadata", "codex_history_assistant_item", "merge_codex_history_duplicate",
     "codex_history_user_event_item",

--- a/test_codex_subagent_notification_history.py
+++ b/test_codex_subagent_notification_history.py
@@ -1,0 +1,187 @@
+"""Typed runtime input and historical checkpoint proof; no server import."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+import unittest
+from unittest.mock import AsyncMock, Mock
+
+from test_codex_goal_history_isolated import load_projection, source_user
+import test_codex_native_history_repair as native_fixture
+
+
+KIND = "multi_agent.subagent_notification"
+PROVIDER = native_fixture.PROVIDER
+_PREFIX = '<subagent_notification>{"agent_path":"example-child","status":{"completed":"'
+_SUFFIX = '"}}</subagent_notification>'
+TEXT = _PREFIX + ("Public child result. " * 80)[:1200 - len(_PREFIX) - len(_SUFFIX)] + _SUFFIX
+STAMP = "2026-09-11T20:33:38.446Z"
+ABORT_TEXT = ("<turn_aborted>The user interrupted the previous turn on purpose. "
+              "Any running unified exec processes may still be running in the background. "
+              "If any tools/commands were aborted, they may have partially executed.</turn_aborted>")
+
+
+def source(**fields):
+    return {**source_user(TEXT, kinds=(KIND,), **fields), "timestamp": STAMP}
+
+
+def historical_fixture(runtime_kind="subagent_notification"):
+    case = native_fixture.CodexNativeHistoryRepairTests()
+    case.setUp()
+    case.native = []  # Typed runtime provenance does not invent a native user turn.
+    case.raw = [source() if runtime_kind == "subagent_notification" else {
+        **source_user(ABORT_TEXT, kinds=("generic.turn_aborted",)), "timestamp": STAMP}]
+    case.fixture()
+    case.imports[0].pop("provider_user_authored", None)
+    rows = [json.loads(line) for line in case.events.read_text().splitlines()]
+    for row in rows:
+        if row.get("id") == case.imports[0]["id"]:
+            row.pop("provider_user_authored", None)
+    case.events.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return case
+
+
+class CodexSubagentNotificationHistoryTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.ns = load_projection()
+
+    def test_exclusive_provider_kind_classifies_but_human_quotations_and_unknowns_stay(self):
+        parse = self.ns["codex_history_event_item"]
+        raw = source()
+        before = copy.deepcopy(raw)
+        item = parse(raw)
+        self.assertEqual(item["provider_runtime_context"], "subagent_notification")
+        self.assertEqual(item["provider_origin"]["kind"], "subagent_notification")
+        self.assertEqual(item["provider_origin"]["source_text_sha256"], hashlib.sha256(TEXT.encode()).hexdigest())
+        self.assertEqual(raw, before)
+        for extra in ({"provider_user_authored": True}, {"clientUserMessageId": "client-input"},
+                      {"origin": {"provider": "codex", "kind": "human"}}):
+            self.assertNotIn("provider_runtime_context", parse(source(**extra)))
+        for kinds in (None, [], ["user.text"], [KIND, "user.text"], [KIND, "unknown"], "multi_agent.subagent_notification"):
+            raw = source()
+            raw["payload"]["internal_chat_message_metadata_passthrough"]["content_item_kinds"] = kinds
+            self.assertNotIn("provider_runtime_context", parse(raw))
+        for text in (TEXT[:-2], "Quoted: " + TEXT, TEXT + " genuine text", '<subagent_notification>{"agent_path":"x","status":"completed"}</subagent_notification>'):
+            raw = source()
+            raw["payload"]["content"][0]["text"] = text
+            self.assertNotIn("provider_runtime_context", parse(raw))
+
+    async def test_typed_abort_uses_same_silent_import_and_repair_without_stopping_current_work(self):
+        parse = self.ns["codex_history_event_item"]
+        raw = {**source_user(ABORT_TEXT, kinds=("generic.turn_aborted",)), "timestamp": STAMP}
+        item = parse(raw)
+        self.assertEqual(item["provider_runtime_context"], "turn_aborted")
+        self.assertEqual(item["provider_origin"]["kind"], "turn_aborted")
+        for kinds in (None, ("user.text",), ("generic.turn_aborted", "user.text"), ("unknown",)):
+            quote = {**source_user(ABORT_TEXT, kinds=kinds), "timestamp": STAMP}
+            self.assertNotIn("provider_runtime_context", parse(quote))
+        for extra in ({"provider_user_authored": True}, {"clientId": "human"}):
+            quote = copy.deepcopy(raw); quote["payload"].update(extra)
+            self.assertNotIn("provider_runtime_context", parse(quote))
+        partial = copy.deepcopy(raw); partial["payload"]["content"][0]["text"] = ABORT_TEXT[:-2]
+        self.assertNotIn("provider_runtime_context", parse(partial))
+        self.ns["append_durable_event_batch"] = AsyncMock(side_effect=lambda _session, specs: [{"seq": n + 1, **value} for n, (_kind, value) in enumerate(specs)])
+        await self.ns["append_imported_history"]({"id": "chat", "backend": "codex", "codex_thread_id": PROVIDER}, Path("unused"), [item, {"kind": "assistant", "text": "Unrelated answer remains."}])
+        rows = self.ns["append_durable_event_batch"].await_args.args[1]
+        self.assertEqual([kind for kind, _value in rows], ["history_imported", "turn_started", "assistant_text", "turn_finished"])
+        self.assertEqual(rows[1][1]["prompt"], "")
+        self.assertEqual(rows[1][1]["provider_runtime_context"], "turn_aborted")
+        self.assertEqual(rows[2][1]["text"], "Unrelated answer remains.")
+        case = historical_fixture("turn_aborted"); self.addCleanup(case.doCleanups); case.prepare()
+        projected = case.cache.project_event("chat", case.imports[0])
+        self.assertEqual(projected["provider_runtime_context"], "turn_aborted")
+        self.assertEqual(projected["ts"], STAMP)
+        self.assertNotIn("stopped", projected)
+        self.assertEqual(projected["prompt"], "")
+
+    async def test_both_import_paths_keep_silent_boundary_timestamp_and_following_answer(self):
+        item = self.ns["codex_history_event_item"](source())
+        answer = {"kind": "assistant", "text": "Unmatched following answer stays."}
+        async def durable(_session, specs):
+            return [{"seq": index + 1, **value} for index, (_kind, value) in enumerate(specs)]
+        self.ns["append_durable_event_batch"] = AsyncMock(side_effect=durable)
+        self.ns["append_imported_events"] = AsyncMock(side_effect=lambda _session, specs: len(specs))
+        session = {"id": "chat", "backend": "codex", "codex_thread_id": PROVIDER}
+        for name, sink in (("append_imported_history", "append_durable_event_batch"), ("append_staged_imported_history", "append_imported_events")):
+            await self.ns[name](session, Path("unused-source.jsonl"), [item, answer])
+            rows = self.ns[sink].await_args.args[1]
+            self.assertEqual([kind for kind, _ in rows], ["history_imported", "turn_started", "assistant_text", "turn_finished"])
+            payload = rows[1][1]
+            self.assertEqual(payload["prompt"], "")
+            self.assertTrue(payload["metadata_only"])
+            self.assertEqual(payload["provider_runtime_context"], "subagent_notification")
+            self.assertEqual(payload["ts"], STAMP)
+            self.assertEqual(payload["provider_origin"]["session_id"], PROVIDER)
+            self.assertEqual(rows[2][1]["text"], answer["text"])
+        self.ns["bounded_jsonl_events"] = Mock(return_value=iter([source(), source_user("Real title", kinds=("user.text",))]))
+        self.assertEqual(self.ns["codex_transcript_preview"](Path("unused")), "Real title")
+
+    def test_identical_genuine_quote_after_committed_runtime_cursor_is_not_consumed(self):
+        runtime = self.ns["codex_history_event_item"](source())
+        human_record = {**source_user(TEXT, kinds=("user.text",)), "timestamp": STAMP}
+        human = self.ns["codex_history_event_item"](human_record)
+        digest = self.ns["history_item_cursor_digest"]
+        self.assertNotEqual(digest(runtime), digest(human))
+        self.assertEqual(digest(human), digest({"kind": "user", "text": TEXT}))
+        self.ns["bounded_jsonl_records_range"] = Mock(return_value=iter([(human_record, 10)]))
+        items, offset, _digest, blocked = self.ns["parse_provider_history_delta"](
+            Path("unused"), "codex", 0, 10, limit=10, expected_stat={},
+            previous_last_item_digest=digest(runtime), codex_phase_context={},
+        )
+        self.assertEqual(items, [human])
+        self.assertEqual(offset, 10)
+        self.assertFalse(blocked)
+
+    def test_old_import_requires_exact_checkpoint_identity_and_preserves_all_source_bytes(self):
+        case = historical_fixture()
+        self.addCleanup(case.doCleanups)
+        before = case.events.read_bytes(), case.source.read_bytes()
+        case.prepare()
+        projected = case.cache.project_event("chat", case.imports[0])
+        self.assertEqual(projected["prompt"], "")
+        self.assertEqual(projected["ts"], STAMP)
+        self.assertEqual(projected["provider_runtime_context"], "subagent_notification")
+        self.assertEqual(projected["provider_origin"]["kind"], "subagent_notification")
+        self.assertNotIn("provider_history_repair", projected)
+        persisted = {**projected, "session_id": "chat"}
+        self.assertIsNotNone(case.cache.project_event("chat", persisted))
+        for changed in ({"clientId": "human-client"}, {"provider_user_authored": True}, {"id": ""},
+                        {"ts": "2026-09-11T20:33:39Z"}, {"provider_origin": {**persisted["provider_origin"], "turn_id": ""}}):
+            self.assertIsNone(case.cache.project_event("chat", {**persisted, **changed}))
+        self.assertEqual(before, (case.events.read_bytes(), case.source.read_bytes()))
+        for changed in ({"provider_user_authored": True}, {"clientId": "actual-human"},
+                        {"provider_origin": {"kind": "user"}}, {"prompt": TEXT + " quote"}, {"ts": "2026-09-11T20:33:39Z"}):
+            self.assertIsNone(case.cache.project_event("chat", {**case.imports[0], **changed}))
+        case.cache.forget("chat")
+        rows = [json.loads(line) for line in case.events.read_text().splitlines()]
+        rows[0]["_history_sync_checkpoint"]["cursor"]["source_digest"] = "0" * 64
+        case.events.write_text("".join(json.dumps(row) + "\n" for row in rows))
+        case.prepare()
+        self.assertIsNone(case.cache.project_event("chat", case.imports[0]))
+
+    def test_fork_prefix_requires_exact_declared_parent_and_current_first_owner(self):
+        parent = "22222222-3333-4444-5555-666666666666"
+        for linked, first_owner in ((True, PROVIDER), (False, PROVIDER), (True, parent)):
+            with self.subTest(linked=linked, first_owner=first_owner):
+                case = historical_fixture()
+                self.addCleanup(case.doCleanups)
+                source_rows = [json.loads(line) for line in case.source.read_text().splitlines()]
+                source_rows[0]["payload"]["id"] = first_owner
+                if linked:
+                    source_rows[0]["payload"]["forked_from_id"] = parent
+                source_rows.insert(1, {"type": "session_meta", "payload": {"id": parent}})
+                body = "".join(json.dumps(row) + "\n" for row in source_rows).encode()
+                case.source.write_bytes(body)
+                ledger = [json.loads(line) for line in case.events.read_text().splitlines()]
+                ledger[0]["_history_sync_checkpoint"]["cursor"].update(
+                    source_offset=len(body), source_digest=hashlib.sha256(body).hexdigest())
+                case.events.write_text("".join(json.dumps(row) + "\n" for row in ledger))
+                case.prepare()
+                corrected = case.cache.project_event("chat", case.imports[0])
+                self.assertEqual(corrected is not None, linked and first_owner == PROVIDER)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Classify typed subagent and interruption notices as runtime metadata, not human messages. Repair old imports only with exact checkpoint, identity, timestamp and full-text source proof, including declared fork ancestry. Keep user quotations, native activity and following answers unchanged. Includes focused isolated regressions and public release documentation; no provider transcript rewrite or background polling.