### PR TITLE
Cover typed provider notices and all terminal subagent states

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -44579,13 +44579,14 @@ def normalized_history_item(
     *,
     provider_origin: Any = None,
     source_text_sha256: Any = None,
+    allow_user_boilerplate: bool = False,
 ) -> dict[str, Any] | None:
     origin = normalized_history_provider_origin(provider_origin)
     if kind == "interruption" and (origin is None or origin.get("kind") != "interruption"):
         return None
     source_key = history_dedup_key(kind, text, source_text_sha256=source_text_sha256)[1]
     text = compact_import_text(text)
-    if not text or (kind == "user" and is_import_boilerplate(text)):
+    if not text or (kind == "user" and not allow_user_boilerplate and is_import_boilerplate(text)):
         return None
     item: dict[str, Any] = {"kind": kind, "text": text}
     if source_key != history_dedup_key(kind, text)[1]:
@@ -46041,13 +46042,31 @@ def codex_history_user_record(event: dict[str, Any]) -> tuple[dict[str, Any], st
 
 
 def codex_runtime_user_item_kind(item: dict[str, Any], text: str) -> str | None:
-    """Two explicitly typed provider inputs, never a text-only quotation filter."""
+    """Known explicitly typed provider inputs, never a text-only quotation filter."""
     if item.get("type") != "message" or item.get("role") != "user" or codex_user_item_has_human_provenance(item):
         return None
     metadata = item.get("internal_chat_message_metadata_passthrough")
     kinds = metadata.get("content_item_kinds") if isinstance(metadata, dict) else None
     if not isinstance(kinds, list) or not kinds:
         return None
+    pure_notices = {
+        "compaction.summary", "apply_patch.legacy_exec_command_warning",
+        "model_switch.legacy_mismatch_warning", "unified_exec.legacy_process_limit_warning",
+        "guardian.node_repl_review_evidence", "plugins.recommendations", "agents_md.instructions",
+    }
+    if isinstance(kinds[0], str) and kinds[0] in pure_notices and all(kind == kinds[0] for kind in kinds):
+        candidate = str(text or "").strip()
+        if not candidate:
+            return None
+        wrapper = {"guardian.node_repl_review_evidence": "node_repl_review_evidence",
+                   "plugins.recommendations": "recommended_plugins"}.get(kinds[0])
+        if wrapper and not re.fullmatch(r"<" + wrapper + r">\s*[\s\S]+?\s*</" + wrapper + r">", candidate):
+            return None
+        if kinds[0] == "agents_md.instructions" and not (
+                candidate.startswith("# AGENTS.md instructions")
+                and "\n<INSTRUCTIONS>" in candidate and candidate.endswith("</INSTRUCTIONS>")):
+            return None
+        return "provider_notice"
     if all(kind == "generic.turn_aborted" for kind in kinds):
         match = re.fullmatch(r"<turn_aborted>\s*([\s\S]*?)\s*</turn_aborted>", str(text or "").strip())
         return "turn_aborted" if match is not None and match.group(1).strip() else None
@@ -46063,9 +46082,15 @@ def codex_runtime_user_item_kind(item: dict[str, Any], text: str) -> str | None:
     if not isinstance(notification, dict) or set(notification) != {"agent_path", "status"}:
         return None
     path, status = notification["agent_path"], notification["status"]
+    terminal_status = (
+        isinstance(status, str) and status in {"shutdown", "not_found"}
+        or isinstance(status, dict) and (
+            set(status) == {"completed"} and (status["completed"] is None or isinstance(status["completed"], str))
+            or set(status) == {"errored"} and isinstance(status["errored"], str)
+        )
+    )
     return "subagent_notification" if (isinstance(path, str) and 0 < len(path.strip()) <= 256
-            and isinstance(status, dict) and set(status) == {"completed"}
-            and isinstance(status["completed"], str)) else None
+            and terminal_status) else None
 
 
 def is_codex_subagent_notification_user_item(item: dict[str, Any], text: str) -> bool:
@@ -46087,6 +46112,8 @@ def codex_history_user_item(
             expected_session_id=expected_session_id,
             provider_history=True,
         ),
+        allow_user_boilerplate=(codex_user_item_has_human_provenance(payload)
+                               or codex_runtime_user_item_kind(payload, text) == "provider_notice"),
     )
     if item is not None and codex_user_item_has_human_provenance(payload):
         item["provider_user_authored"] = True
@@ -46142,10 +46169,14 @@ def codex_history_user_event_item(
         origin = codex_public_item_origin(event)
         if origin is not None:
             runtime_kind = codex_runtime_user_item_kind(payload, text)
-            if (runtime_kind is not None
-                    and item.get("text") == text.strip() and item.get("source_text_sha256") is None):
+            if (runtime_kind is not None and (runtime_kind == "provider_notice"
+                    or item.get("text") == text.strip() and item.get("source_text_sha256") is None)):
+                full_source_hash = item.get("source_text_sha256")
+                runtime_hash = (full_source_hash if isinstance(full_source_hash, str)
+                                and re.fullmatch(r"[0-9a-f]{64}", full_source_hash)
+                                else hashlib.sha256(item["text"].encode("utf-8", errors="surrogatepass")).hexdigest())
                 origin = {**origin, "kind": runtime_kind,
-                    "source_text_sha256": hashlib.sha256(item["text"].encode("utf-8", errors="surrogatepass")).hexdigest()}
+                    "source_text_sha256": runtime_hash}
                 item["provider_runtime_context"] = runtime_kind
             item["provider_origin"] = origin
     return item
@@ -46358,7 +46389,7 @@ def codex_transcript_preview(path: Path) -> str | None:
             if index >= CODEX_TRANSCRIPT_SCAN_LINES:
                 break
             item = codex_history_event_item(event)
-            if item is not None and item.get("kind") == "user" and item.get("provider_runtime_context") not in ("subagent_notification", "turn_aborted"):
+            if item is not None and item.get("kind") == "user" and item.get("provider_runtime_context") not in ("subagent_notification", "turn_aborted", "provider_notice"):
                 return item["text"][:160]
     return None
 
@@ -46536,7 +46567,7 @@ def provider_history(sess: dict[str, Any], limit: int | None) -> tuple[Path | No
 def history_item_cursor_digest(item: dict[str, Any]) -> str:
     identity = [str(item.get("kind") or ""), str(item.get("text") or "").strip()]
     runtime_origin = item.get("provider_origin")
-    if (item.get("kind") == "user" and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted")
+    if (item.get("kind") == "user" and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted", "provider_notice")
         and item.get("provider_user_authored") is not True and isinstance(runtime_origin, dict)
         and runtime_origin.get("provider") == "codex" and runtime_origin.get("kind") == item["provider_runtime_context"]
         and all(isinstance(runtime_origin.get(key), str) and runtime_origin[key] for key in ("event_id", "turn_id"))):
@@ -47903,7 +47934,7 @@ async def append_imported_history(
         )
         provenance: dict[str, Any] = {"provider_origin": origin} if origin is not None else {}
         runtime_notification = (backend == BACKEND_CODEX and item.get("kind") == "user"
-            and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted")
+            and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted", "provider_notice")
             and item.get("provider_user_authored") is not True and origin is not None
             and origin.get("kind") == item["provider_runtime_context"])
         if runtime_notification:
@@ -48018,7 +48049,7 @@ async def append_staged_imported_history(
         )
         provenance: dict[str, Any] = {"provider_origin": origin} if origin is not None else {}
         runtime_notification = (backend == BACKEND_CODEX and item.get("kind") == "user"
-            and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted")
+            and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted", "provider_notice")
             and item.get("provider_user_authored") is not True and origin is not None
             and origin.get("kind") == item["provider_runtime_context"])
         if runtime_notification:

--- a/codex_history_repair.py
+++ b/codex_history_repair.py
@@ -342,7 +342,7 @@ def _runtime_human_provenance(event: dict) -> bool:
 def _persisted_runtime_marker(event: dict, session_id: str) -> bool:
     origin = event.get("provider_origin")
     runtime_kind = event.get("provider_runtime_context")
-    if (runtime_kind not in ("subagent_notification", "turn_aborted")
+    if (runtime_kind not in ("subagent_notification", "turn_aborted", "provider_notice")
         or event.get("metadata_only") is not True or event.get("backend") != "codex"
         or event.get("imported") is not True or not isinstance(event.get("run_id"), str)
         or not event["run_id"].startswith("import_") or event.get("session_id") != session_id
@@ -518,7 +518,7 @@ def _prove_native_source(thread: str, source: Path, root: Path, batches: dict, c
             continue
         origin = codex_public_item_origin(record, thread)
         runtime_kind = item.get("provider_runtime_context")
-        if (origin and runtime_kind in ("subagent_notification", "turn_aborted")
+        if (origin and runtime_kind in ("subagent_notification", "turn_aborted", "provider_notice")
                 and item.get("provider_user_authored") is not True
                 and (item.get("provider_origin") or {}).get("kind") == runtime_kind):
             origin = {**origin, "kind": runtime_kind}
@@ -551,7 +551,7 @@ def _prove_native_source(thread: str, source: Path, root: Path, batches: dict, c
             # hash. Until one exists, the bounded preview cannot prove equality.
             continue
         source_origin = next(iter(source_ids.values()))
-        if source_origin.get("kind") in ("subagent_notification", "turn_aborted"):
+        if source_origin.get("kind") in ("subagent_notification", "turn_aborted", "provider_notice"):
             if kind == "user" and not _human:
                 proofs[target] = {**source_origin, "source_text_sha256": body_key}
                 if len(proofs) > MAX_TARGETS:
@@ -620,7 +620,7 @@ class CodexNativeHistoryRepairCache(CodexGoalHistoryRepairCache):
         origin = proof.targets.get(target) if target else None
         if origin is None:
             return None
-        if origin.get("kind") in ("subagent_notification", "turn_aborted"):
+        if origin.get("kind") in ("subagent_notification", "turn_aborted", "provider_notice"):
             return {**event, "prompt": "", "metadata_only": True,
                     "provider_runtime_context": origin["kind"], "provider_origin": origin,
                     "_agentsdock_imported_prompt_hidden": True}

--- a/docs/CODEX_HISTORY_METADATA.md
+++ b/docs/CODEX_HISTORY_METADATA.md
@@ -52,6 +52,21 @@ provider identity, and no positive human/client provenance. Ordinary quotations
 and unknown or mixed kinds remain visible. Silent imported boundaries preserve
 following answers without creating a new human message or changing live state.
 
+Subagent notifications cover completed results (including null), errors,
+shutdown and not-found terminal states. The same provenance boundary also
+recognizes these exact infrastructure kinds as `provider_notice`:
+`compaction.summary`, `apply_patch.legacy_exec_command_warning`,
+`model_switch.legacy_mismatch_warning`, `unified_exec.legacy_process_limit_warning`,
+`guardian.node_repl_review_evidence`, `plugins.recommendations` and
+`agents_md.instructions`. Compaction and legacy warnings have no mandatory text
+wrapper; their explicit type is required. Delimited kinds require their complete
+envelope. No wildcard type or text-prefix rule identifies these notices.
+
+User-invoked shell commands, realtime user delegation and unsupported human media
+remain content. Unknown extension context types are not silently discarded.
+Positive human provenance preserves literal project/plugin instruction quotations
+through the existing bounded normalizer and generated-authority sanitizer.
+
 Older imported copies are projected only after checkpoint, source digest,
 message identity, original timestamp and complete text prove the same record.
 A forked transcript may contain its explicitly declared ancestor headers; an

--- a/docs/RELEASE_0.1.26-beta.61.md
+++ b/docs/RELEASE_0.1.26-beta.61.md
@@ -19,8 +19,10 @@ published desktop beta.33 binary.
   native turn ownership, message identity, timestamp and full text prove the
   replay. Preserve original human messages and scheduled reports. Retain source
   identity on new imports and prevent known native messages becoming new input.
-- Keep explicitly typed Codex subagent notifications and interruption notices
-  out of user-message bubbles. Correct older imports only with exact native
+- Keep explicitly typed Codex subagent notifications, interruption notices,
+  compaction summaries and infrastructure notices out of user-message bubbles.
+  Cover all supported terminal subagent states, not just successful results.
+  Correct older imports only with exact native
   source proof, including declared fork ancestry. Preserve genuine quotations,
   original timestamps, answers and live lifecycle state; no transcript rewrite
   or additional background polling is involved.

--- a/test_codex_subagent_notification_history.py
+++ b/test_codex_subagent_notification_history.py
@@ -21,17 +21,26 @@ STAMP = "2026-09-11T20:33:38.446Z"
 ABORT_TEXT = ("<turn_aborted>The user interrupted the previous turn on purpose. "
               "Any running unified exec processes may still be running in the background. "
               "If any tools/commands were aborted, they may have partially executed.</turn_aborted>")
+PURE_NOTICES = {
+    "compaction.summary": "Synthetic provider compaction summary.",
+    "apply_patch.legacy_exec_command_warning": "Synthetic provider apply-patch warning.",
+    "model_switch.legacy_mismatch_warning": "Synthetic provider model warning.",
+    "unified_exec.legacy_process_limit_warning": "Synthetic provider process-limit warning.",
+    "guardian.node_repl_review_evidence": "<node_repl_review_evidence>Provider context.</node_repl_review_evidence>",
+    "plugins.recommendations": "<recommended_plugins>Provider plugin context.</recommended_plugins>",
+    "agents_md.instructions": "# AGENTS.md instructions for /example\n\n<INSTRUCTIONS>\nProvider project context.\n</INSTRUCTIONS>",
+}
 
 
 def source(**fields):
     return {**source_user(TEXT, kinds=(KIND,), **fields), "timestamp": STAMP}
 
 
-def historical_fixture(runtime_kind="subagent_notification"):
+def historical_fixture(runtime_kind="subagent_notification", *, source_record=None):
     case = native_fixture.CodexNativeHistoryRepairTests()
     case.setUp()
     case.native = []  # Typed runtime provenance does not invent a native user turn.
-    case.raw = [source() if runtime_kind == "subagent_notification" else {
+    case.raw = [source_record if source_record is not None else source() if runtime_kind == "subagent_notification" else {
         **source_user(ABORT_TEXT, kinds=("generic.turn_aborted",)), "timestamp": STAMP}]
     case.fixture()
     case.imports[0].pop("provider_user_authored", None)
@@ -95,6 +104,86 @@ class CodexSubagentNotificationHistoryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(projected["ts"], STAMP)
         self.assertNotIn("stopped", projected)
         self.assertEqual(projected["prompt"], "")
+
+    def test_provider_terminal_status_variants_share_runtime_role_but_unknowns_and_quotes_do_not(self):
+        parse = self.ns["codex_history_event_item"]
+        for status in ({"completed": "Public result"}, {"completed": None},
+                       {"errored": "Public failure"}, "shutdown", "not_found"):
+            with self.subTest(status=status):
+                raw = source()
+                text = "<subagent_notification>" + json.dumps({"agent_path": "example-child", "status": status}) + "</subagent_notification>"
+                raw["payload"]["content"][0]["text"] = text
+                item = parse(raw)
+                self.assertEqual(item["provider_runtime_context"], "subagent_notification")
+                self.assertEqual(item["provider_origin"]["source_text_sha256"], hashlib.sha256(text.encode()).hexdigest())
+                for extra in ({"provider_user_authored": True}, {"clientUserMessageId": "human-input"}):
+                    quote = copy.deepcopy(raw); quote["payload"].update(extra)
+                    self.assertNotIn("provider_runtime_context", parse(quote))
+                mixed = copy.deepcopy(raw)
+                mixed["payload"]["internal_chat_message_metadata_passthrough"]["content_item_kinds"] = [KIND, "user.text"]
+                self.assertNotIn("provider_runtime_context", parse(mixed))
+        for status in ("running", "interrupted", "pending_init", "unknown", "", None,
+                       [], {}, {"completed": False}, {"completed": []}, {"errored": None},
+                       {"completed": "ok", "errored": "bad"}, {"unknown": "value"}):
+            raw = source()
+            raw["payload"]["content"][0]["text"] = "<subagent_notification>" + json.dumps({"agent_path": "example-child", "status": status}) + "</subagent_notification>"
+            self.assertNotIn("provider_runtime_context", parse(raw))
+
+    async def test_exact_pure_provider_kinds_keep_bounded_proof_and_never_emit_raw_prompt(self):
+        parse = self.ns["codex_history_event_item"]
+        for kind, text in PURE_NOTICES.items():
+            with self.subTest(kind=kind):
+                raw = {**source_user(text, kinds=(kind,)), "timestamp": STAMP}
+                before = copy.deepcopy(raw)
+                item = parse(raw)
+                self.assertEqual(item["provider_runtime_context"], "provider_notice")
+                self.assertEqual(item["provider_origin"]["kind"], "provider_notice")
+                self.assertEqual(item["provider_origin"]["source_text_sha256"], hashlib.sha256(text.encode()).hexdigest())
+                self.assertEqual(raw, before)
+                for extra in ({"provider_user_authored": True}, {"clientId": "human"}):
+                    quoted = copy.deepcopy(raw); quoted["payload"].update(extra)
+                    human = parse(quoted)
+                    self.assertEqual(human["text"], text)
+                    self.assertNotIn("provider_runtime_context", human)
+                mixed = {**source_user(text, kinds=(kind, "user.text")), "timestamp": STAMP}
+                self.assertEqual(parse(mixed)["text"], text)
+                self.assertNotIn("provider_runtime_context", parse(mixed))
+                mixed_unknown = {**source_user("Plain runtime context", kinds=(kind, "unknown")), "timestamp": STAMP}
+                self.assertNotIn("provider_runtime_context", parse(mixed_unknown))
+        for kind in ("shell.user_command", "realtime_conversation.delegation", "images.unsupported", "audio.unsupported", "extension.internal_context", "unknown"):
+            item = parse({**source_user("User or unknown content remains.", kinds=(kind,)), "timestamp": STAMP})
+            self.assertEqual(item["text"], "User or unknown content remains.")
+            self.assertNotIn("provider_runtime_context", item)
+        for kinds in ([{}], [[]], ["compaction.summary", {}], ["compaction.summary", []]):
+            malformed = {**source_user("Malformed metadata remains visible.", kinds=kinds), "timestamp": STAMP}
+            self.assertNotIn("provider_runtime_context", parse(malformed))
+        for kind in ("guardian.node_repl_review_evidence", "plugins.recommendations", "agents_md.instructions"):
+            self.assertIsNone(self.ns["codex_runtime_user_item_kind"](source_user(PURE_NOTICES[kind], kinds=(kind,))["payload"], PURE_NOTICES[kind][:-2]))
+        raw = {**source_user("Large provider context. " * 50, kinds=("compaction.summary",)), "timestamp": STAMP}
+        self.ns["MAX_IMPORTED_TEXT_CHARS"] = 64
+        item = parse(raw)
+        self.assertLess(len(item["text"]), 100)
+        self.assertIn("source_text_sha256", item)
+        self.assertEqual(item["provider_origin"]["source_text_sha256"], item["source_text_sha256"])
+        self.ns["append_durable_event_batch"] = AsyncMock(side_effect=lambda _session, specs: [{"seq": n + 1, **value} for n, (_kind, value) in enumerate(specs)])
+        await self.ns["append_imported_history"]({"id": "chat", "backend": "codex", "codex_thread_id": PROVIDER}, Path("unused"), [item])
+        rows = self.ns["append_durable_event_batch"].await_args.args[1]
+        self.assertEqual(rows[1][1]["prompt"], "")
+        self.assertEqual(rows[1][1]["provider_runtime_context"], "provider_notice")
+
+    def test_historical_compaction_and_warning_require_exact_source_checkpoint(self):
+        for kind in ("compaction.summary", "unified_exec.legacy_process_limit_warning"):
+            raw = {**source_user(PURE_NOTICES[kind], kinds=(kind,)), "timestamp": STAMP}
+            case = historical_fixture(source_record=raw); self.addCleanup(case.doCleanups)
+            before = case.events.read_bytes(), case.source.read_bytes()
+            case.prepare()
+            projected = case.cache.project_event("chat", case.imports[0])
+            self.assertEqual(projected["provider_runtime_context"], "provider_notice")
+            self.assertEqual(projected["prompt"], "")
+            self.assertEqual(projected["ts"], STAMP)
+            self.assertEqual(before, (case.events.read_bytes(), case.source.read_bytes()))
+            self.assertIsNone(case.cache.project_event("chat", {**case.imports[0], "provider_user_authored": True}))
+            self.assertIsNone(case.cache.project_event("chat", {**case.imports[0], "prompt": PURE_NOTICES[kind] + " quote"}))
 
     async def test_both_import_paths_keep_silent_boundary_timestamp_and_following_answer(self):
         item = self.ns["codex_history_event_item"](source())


### PR DESCRIPTION
Complete the runtime-input classification with the seven exact provider-only context kinds and supported terminal subagent states. Reuse existing bounded source/checkpoint proof and blank metadata boundaries. Preserve genuine user quotations, shell commands, realtime delegation, media, mixed provenance and unknown types. Forward large notices remain bounded and retain the full-source digest. Focused server and desktop checks passed; isolated actual Electron verification uses synthetic transport. No additional polling or transcript rewrites.