### PR TITLE
Fix Claude history reply deduplication by provider identity

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -45070,7 +45070,8 @@ def message_text(message: Any, *, compact: bool = True) -> str:
 def normalized_history_provider_origin(value: Any) -> dict[str, str] | None:
     """Keep only validated Claude identifiers and the original aware timestamp.
 
-    This metadata is descriptive, never authority or a message-matching key.
+    This metadata is descriptive, never authority. Assistant reconciliation
+    can correlate its validated message identity with this chat's live events.
     Validate fields independently so one malformed timestamp cannot erase a
     valid source identity, and never copy transcript paths or context fields.
     """
@@ -45147,6 +45148,22 @@ def add_history_item(
             previous_origin = normalized_history_provider_origin(items[-1].get("provider_origin"))
             origin = item["provider_origin"]
             if previous_origin is not None and all(previous_origin.get(field) == origin.get(field) for field in ("event_id", "session_id")):
+                return
+        elif item["kind"] == "assistant" and any(
+            origin is not None and all(origin.get(field) for field in ("event_id", "session_id"))
+            for origin in (
+                normalized_history_provider_origin(items[-1].get("provider_origin")),
+                normalized_history_provider_origin(item.get("provider_origin")),
+            )
+        ):
+            previous_origin = normalized_history_provider_origin(items[-1].get("provider_origin"))
+            origin = normalized_history_provider_origin(item.get("provider_origin"))
+            # A distinct provider message remains a real occurrence even if
+            # its text repeats. An identityless row cannot consume its credit.
+            if previous_origin is not None and origin is not None and all(
+                previous_origin.get(field, "").lower() == origin.get(field, "").lower()
+                for field in ("event_id", "session_id")
+            ):
                 return
         elif items[-1]["text"].strip() == item["text"].strip() and history_dedup_key(
             kind, items[-1]["text"], source_text_sha256=items[-1].get("source_text_sha256"),
@@ -47131,6 +47148,12 @@ def provider_history(sess: dict[str, Any], limit: int | None) -> tuple[Path | No
 def history_item_cursor_digest(item: dict[str, Any]) -> str:
     identity = [str(item.get("kind") or ""), str(item.get("text") or "").strip()]
     runtime_origin = item.get("provider_origin")
+    if item.get("kind") == "assistant":
+        origin = normalized_history_provider_origin(runtime_origin)
+        if origin is not None and all(origin.get(field) for field in ("event_id", "session_id")):
+            # Legacy text-only cursors safely mismatch the first identified
+            # boundary row; never discard a newly appended repeated reply.
+            identity = ["assistant", "claude", origin["session_id"].lower(), origin["event_id"].lower()]
     if (item.get("kind") == "user" and item.get("provider_runtime_context") in ("subagent_notification", "turn_aborted", "provider_notice")
         and item.get("provider_user_authored") is not True and isinstance(runtime_origin, dict)
         and runtime_origin.get("provider") == "codex" and runtime_origin.get("kind") == item["provider_runtime_context"]
@@ -47832,6 +47855,72 @@ def history_dedup_key(
     return str(kind or ""), hashlib.sha256(normalized.encode("utf-8", errors="surrogatepass")).hexdigest() if normalized else ""
 
 
+def history_message_match_details(
+    kind: str, text: Any, metadata: dict[str, Any], *, provider_item: bool = False,
+) -> dict[str, Any]:
+    """Keep exact text and Claude ownership separate from display cleaning."""
+    key = history_dedup_key(kind, text, source_text_sha256=metadata.get("source_text_sha256"))
+    details: dict[str, Any] = {"key": key, "backend": str(metadata.get("backend") or ""), "provider_item": provider_item}
+    if kind != "assistant":
+        return details
+    raw_origin = metadata.get("provider_origin")
+    if not details["backend"] and isinstance(raw_origin, dict):
+        details["backend"] = str(raw_origin.get("provider") or "")
+    if details["backend"] not in ("", BACKEND_CLAUDE):
+        return details
+    origin = normalized_history_provider_origin(metadata.get("provider_origin")) or {}
+    if origin or details["backend"] == BACKEND_CLAUDE:
+        details["backend"] = BACKEND_CLAUDE
+        identity = normalized_history_provider_origin({
+            "provider": "claude",
+            "event_id": origin.get("event_id") or metadata.get("provider_message_id"),
+            "session_id": origin.get("session_id") or metadata.get("provider_session_id"),
+        }) or {}
+        details["message_id"] = str(identity.get("event_id") or "").lower()
+        details["provider_session_id"] = str(identity.get("session_id") or "").lower()
+    # Never derive a fallback from a truncated display prefix. Its complete
+    # source hash cannot be transformed back into a cleaned-text hash.
+    if details["backend"] in ("", BACKEND_CLAUDE) and key == history_dedup_key(kind, text):
+        details["canonical_key"] = history_dedup_key(kind, clean_assistant_text(text))
+    return details
+
+
+def history_messages_match(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    if left["key"][0] != right["key"][0]:
+        return False
+    claude = BACKEND_CLAUDE in (left.get("backend"), right.get("backend"))
+    if claude and left["key"][0] == "assistant":
+        if any(side.get("backend") not in (None, "", BACKEND_CLAUDE) for side in (left, right)):
+            return False
+        sessions = [side.get("provider_session_id") for side in (left, right)]
+        if all(sessions) and sessions[0] != sessions[1]:
+            return False
+        identities = [side.get("message_id") for side in (left, right)]
+        if all(identities):
+            # A distinct UUID is a distinct occurrence even if text is equal.
+            return identities[0] == identities[1]
+        if any(identities) and any(side.get("provider_item") and not side.get("message_id") for side in (left, right)):
+            # An unidentified source row cannot consume a known live UUID.
+            # The fallback is for legacy live projections missing identity.
+            return False
+    if left["key"] == right["key"]:
+        return True
+    return bool(
+        claude and left.get("canonical_key", ("", ""))[1]
+        and left.get("canonical_key") == right.get("canonical_key")
+    )
+
+
+def history_message_match_tokens(details: dict[str, Any]) -> list[tuple[str, ...]]:
+    kind, digest = details["key"]
+    tokens = [(kind, "text", digest)]
+    if details.get("message_id"):
+        tokens.insert(0, (kind, "claude_id", details["message_id"]))
+    if details.get("canonical_key", ("", ""))[1]:
+        tokens.append((kind, "claude_clean", details["canonical_key"][1]))
+    return tokens
+
+
 def history_timeline_message_keys(
     session_id: str,
     *,
@@ -47839,6 +47928,7 @@ def history_timeline_message_keys(
     timeline_through_seq: int,
     tail: bool,
     include_imported: bool,
+    message_details: dict[int, dict[str, Any]] | None = None,
 ) -> tuple[list[tuple[int, tuple[str, str]]], bool, bool]:
     """Scan a fixed timeline boundary while bounding message credits only.
 
@@ -47859,10 +47949,10 @@ def history_timeline_message_keys(
     except FileNotFoundError:
         raise ValueError("timeline disappeared during history reconciliation")
     maximum = max(1, int(HISTORY_SYNC_EVENT_SCAN_LIMIT))
-    selected: list[tuple[int, tuple[str, str]]] | deque[
-        tuple[int, tuple[str, str]]
-    ]
+    selected: list[dict[str, Any]] | deque[dict[str, Any]]
     selected = deque(maxlen=maximum) if tail else []
+    provider_runs: dict[str, str] = {}
+    prior_message: dict[str, Any] | None = None
     timeline_has_messages = False
     front_window_truncated = False
     last_seq = 0
@@ -47916,13 +48006,17 @@ def history_timeline_message_keys(
                     "timeline event sequence is invalid during history sync"
                 )
             last_seq = raw_seq
-            if raw_seq <= after_seq:
-                continue
             if raw_seq > through_seq:
                 break
             if not event_files_belong_to_session(event, session_id):
                 continue
             event_type = event.get("type")
+            run_id = str(event.get("run_id") or "")
+            if run_id and event_type == "provider_session" and event.get("backend") == BACKEND_CLAUDE:
+                provider_runs[run_id] = str(event.get("provider_session_id") or "")
+                if len(provider_runs) > maximum:
+                    provider_runs.pop(next(iter(provider_runs)))
+            before_window = raw_seq <= after_seq
             if event_type == "turn_started" or is_native_goal_steer_event(event):
                 key = history_dedup_key("user", event.get("prompt"), source_text_sha256=event.get("source_text_sha256"))
             elif event_type == "assistant_text":
@@ -47955,12 +48049,61 @@ def history_timeline_message_keys(
                 key = history_dedup_key("assistant", result_text, source_text_sha256=event.get("source_text_sha256"))
             else:
                 continue
-            timeline_has_messages = True
+            if not before_window:
+                timeline_has_messages = True
             if not include_imported and event.get("imported") is True:
                 # Messages written by an earlier history-import batch are not
                 # evidence that AgentsDock authored matching provider input.
                 # Its exact source checkpoint, not content, makes crash replay
                 # idempotent.
+                continue
+            text = event.get("prompt") if key[0] == "user" else event.get(
+                "result_text" if event_type in {"turn_finished", "job_summary"} else "text"
+            )
+            metadata = {**event}
+            if run_id in provider_runs and not event.get("imported"):
+                metadata["backend"] = metadata.get("backend") or BACKEND_CLAUDE
+                metadata["provider_session_id"] = metadata.get("provider_session_id") or provider_runs[run_id]
+            details = history_message_match_details(key[0], text, metadata)
+            details.update(seq=raw_seq, run_id=run_id)
+            if details.get("message_id") and details.get("canonical_key"):
+                # Hash block joins incrementally: retaining complete text for
+                # every ownership credit would undo the scanner's memory cap.
+                details["_block_hashes"] = [hashlib.sha256(value.encode("utf-8", errors="surrogatepass")) for value in (
+                    " ".join(str(text or "").split()), " ".join(clean_assistant_text(text).split()),
+                )]
+            previous = (selected[-1] if selected else prior_message) if not front_window_truncated else None
+            if previous and run_id and previous.get("run_id") == run_id and key[0] == "assistant":
+                same_identity = bool(
+                    details.get("message_id") and previous.get("message_id")
+                    and history_messages_match(previous, details)
+                )
+                final_alias = bool(
+                    event_type in {"assistant_text", "turn_finished", "job_summary"}
+                    and previous.get("backend") == BACKEND_CLAUDE
+                    and history_messages_match(previous, details)
+                )
+                if same_identity or final_alias:
+                    # SDK TextBlocks and its terminal echo are projections of
+                    # one provider message, not extra occurrence credits.
+                    if same_identity and event_type == "reasoning_summary":
+                        hashes = previous.get("_block_hashes")
+                        if hashes and details.get("_block_hashes"):
+                            for digest, value in zip(hashes, (
+                                " ".join(str(text or "").split()), " ".join(clean_assistant_text(text).split()),
+                            )):
+                                digest.update((" " + value).encode("utf-8", errors="surrogatepass"))
+                            previous["key"] = ("assistant", hashes[0].hexdigest())
+                            previous["canonical_key"] = ("assistant", hashes[1].hexdigest())
+                        else:
+                            previous["key"] = ("assistant", "")
+                            previous.pop("canonical_key", None)
+                    previous["seq"] = raw_seq
+                    continue
+            if before_window:
+                # A later terminal echo of this already-consumed projection
+                # must not create a new ownership credit after the watermark.
+                prior_message = details
                 continue
             if not tail and len(selected) >= maximum:
                 # A valid cursor consumes ownership credits from the front.
@@ -47970,10 +48113,12 @@ def history_timeline_message_keys(
                 # byte cursor instead of wedging forever at this boundary.
                 front_window_truncated = True
                 continue
-            selected.append((raw_seq, key))
+            selected.append(details)
     if last_seq < through_seq:
         raise ValueError("timeline changed during bounded history reconciliation")
-    return list(selected), timeline_has_messages, front_window_truncated
+    if message_details is not None:
+        message_details.update((entry["seq"], {key: value for key, value in entry.items() if not key.startswith("_")}) for entry in selected)
+    return [(entry["seq"], entry["key"]) for entry in selected], timeline_has_messages, front_window_truncated
 
 
 def reconcile_cursor_history_items(
@@ -47995,6 +48140,7 @@ def reconcile_cursor_history_items(
 
     after_seq = max(0, int(timeline_after_seq))
     through_seq = max(after_seq, int(timeline_through_seq))
+    message_details: dict[int, dict[str, Any]] = {}
     (
         timeline_messages,
         _timeline_has_messages,
@@ -48005,19 +48151,19 @@ def reconcile_cursor_history_items(
         timeline_through_seq=through_seq,
         tail=False,
         include_imported=False,
+        message_details=message_details,
     )
 
     fresh: list[dict[str, str]] = []
     timeline_index = 0
     consumed_seq = after_seq
     for item in items:
-        item_key = history_dedup_key(
-            item.get("kind", ""), item.get("text", ""),
-            source_text_sha256=item.get("source_text_sha256"),
-        )
+        item_details = history_message_match_details(item.get("kind", ""), item.get("text", ""), item, provider_item=True)
         if (
             timeline_index < len(timeline_messages)
-            and item_key == timeline_messages[timeline_index][1]
+            and history_messages_match(item_details, message_details.get(
+                timeline_messages[timeline_index][0], {"key": timeline_messages[timeline_index][1]},
+            ))
         ):
             consumed_seq = timeline_messages[timeline_index][0]
             timeline_index += 1
@@ -48074,6 +48220,7 @@ def unsynced_history_items(
         if timeline_through_seq is not None
         else last_event_seq_from_file(events_path(session_id))
     )
+    message_details: dict[int, dict[str, Any]] = {}
     (
         timeline_messages,
         timeline_has_messages,
@@ -48087,14 +48234,12 @@ def unsynced_history_items(
         # silently tail-truncating those credits can hide a later duplicate.
         tail=True,
         include_imported=True,
+        message_details=message_details,
     )
-    timeline_keys = [key for _seq, key in timeline_messages]
+    timeline_details = [message_details.get(seq, {"key": key}) for seq, key in timeline_messages]
 
-    transcript_keys = [
-        history_dedup_key(
-            item.get("kind", ""), item.get("text", ""),
-            source_text_sha256=item.get("source_text_sha256"),
-        )
+    transcript_details = [
+        history_message_match_details(item.get("kind", ""), item.get("text", ""), item, provider_item=True)
         for item in items
     ]
     # Content alone cannot distinguish an original ``A, B`` prefix from the
@@ -48105,11 +48250,11 @@ def unsynced_history_items(
     # newest-backward alignment below so an older repeated answer is not
     # imported ahead of the already-shown current turn.
     if (
-        timeline_keys
-        and len(timeline_keys) <= len(transcript_keys)
-        and transcript_keys[:len(timeline_keys)] == timeline_keys
+        timeline_details
+        and len(timeline_details) <= len(transcript_details)
+        and all(history_messages_match(native, source) for native, source in zip(timeline_details, transcript_details))
     ):
-        return items[len(timeline_keys):]
+        return items[len(timeline_details):]
 
     last_matched = -1
     # Align the newest bounded timeline tail to the transcript in reverse
@@ -48118,19 +48263,29 @@ def unsynced_history_items(
     # still-unseen repeated ``A`` in ``A, B, A``.  Greedily selecting the
     # newest occurrence that remains before the prior match handles repeated
     # text without letting an old duplicate consume the current-tail anchor.
-    transcript_positions: dict[tuple[str, str], list[int]] = defaultdict(list)
-    for index, key in enumerate(transcript_keys):
-        transcript_positions[key].append(index)
+    transcript_positions: dict[tuple[str, ...], list[int]] = defaultdict(list)
+    for index, details in enumerate(transcript_details):
+        for token in history_message_match_tokens(details):
+            transcript_positions[token].append(index)
     transcript_index = len(items) - 1
-    for timeline_key in reversed(timeline_keys):
-        candidates = transcript_positions.get(timeline_key)
-        if not candidates:
+    for details in reversed(timeline_details):
+        candidates: set[int] = set()
+        matched_index = -1
+        for token in history_message_match_tokens(details):
+            positions = transcript_positions.get(token, [])
+            while positions and positions[-1] > transcript_index:
+                positions.pop()
+            if token[1] == "claude_id":
+                matched_index = next((index for index in reversed(positions)
+                    if history_messages_match(details, transcript_details[index])), -1)
+                if matched_index >= 0:
+                    break
+            candidates.update(positions)
+        if matched_index < 0:
+            matched_index = next((index for index in sorted(candidates, reverse=True)
+                if history_messages_match(details, transcript_details[index])), -1)
+        if matched_index < 0:
             continue
-        while candidates and candidates[-1] > transcript_index:
-            candidates.pop()
-        if not candidates:
-            continue
-        matched_index = candidates.pop()
         last_matched = max(last_matched, matched_index)
         transcript_index = matched_index - 1
     if last_matched == -1 and timeline_has_messages and items:

--- a/test_claude_history_provenance_isolated.py
+++ b/test_claude_history_provenance_isolated.py
@@ -30,6 +30,8 @@ FUNCTIONS = {
     "normalized_history_import_limit", "claude_history_event_item", "append_claude_history_event",
     "parse_claude_history_events", "parse_provider_history_delta", "history_item_cursor_digest",
     "history_dedup_key", "reconcile_cursor_history_items", "unsynced_history_items",
+    "history_message_match_details", "history_messages_match", "history_message_match_tokens",
+    "clean_assistant_text",
     "append_imported_history", "append_staged_imported_history", "imported_history_terminal_event",
     "seed_claude_interruption_context", "normalized_history_sync_cursor", "load_provider_history_with_cursor",
     "should_bump_session_updated_at", "is_agent_visible_event",
@@ -72,8 +74,13 @@ def load_projection() -> dict:
     selected = [node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in FUNCTIONS]
     if {node.name for node in selected} != FUNCTIONS:
         raise AssertionError("Isolated provenance helper allowlist is incomplete")
+    constants = [node for node in tree.body if isinstance(node, ast.Assign)
+                 and any(isinstance(target, ast.Name) and target.id == "LEADING_DECORATION_RE" for target in node.targets)]
+    if len(constants) != 1:
+        raise AssertionError("Assistant cleaning constant is missing or ambiguous")
     module = ast.fix_missing_locations(ast.Module(body=[
         ast.ImportFrom(module="__future__", names=[ast.alias(name="annotations")], level=0),
+        *constants,
         *selected,
     ], type_ignores=[]))
     namespace = {
@@ -131,11 +138,44 @@ class ClaudeHistoryProvenanceTests(unittest.TestCase):
         normalize = self.projection["normalized_history_item"]
         self.assertEqual(normalize("user", "  Plain text  "), {"kind": "user", "text": "Plain text"})
         items = []
-        self.projection["add_history_item"](items, "assistant", "Reply", provider_origin=origin())
-        self.projection["add_history_item"](items, "assistant", "Reply", provider_origin=origin(event_id=PARENT_ID))
-        self.assertEqual(items, [{"kind": "assistant", "text": "Reply", "provider_origin": origin()}])
+        self.projection["add_history_item"](items, "assistant", "Reply")
+        self.projection["add_history_item"](items, "assistant", "Reply")
+        self.assertEqual(items, [{"kind": "assistant", "text": "Reply"}])
         digest = self.projection["history_item_cursor_digest"]
-        self.assertEqual(digest(items[0]), digest({"kind": "assistant", "text": "Reply"}))
+        self.assertEqual(digest(items[0]), hashlib.sha256(b'["assistant","Reply"]').hexdigest())
+        self.assertEqual(digest(normalize("user", "Reply", provider_origin=origin())), digest({"kind": "user", "text": "Reply"}))
+        self.assertEqual(digest({**items[0], "provider_origin": {"provider": "codex", "event_id": EVENT_ID, "session_id": SESSION_ID}}), digest(items[0]))
+
+    def test_distinct_assistant_identities_survive_adjacent_dedup(self) -> None:
+        items = []
+        identities = (origin(), origin(event_id=PARENT_ID), origin(session_id=PROMPT_ID))
+        for identity in identities:
+            for text in ("Reply", "A changed rendering of the same provider message"):
+                self.projection["add_history_item"](items, "assistant", text, provider_origin=identity)
+            upper_identity = {**identity, **{field: identity[field].upper() for field in ("event_id", "session_id")}}
+            self.projection["add_history_item"](items, "assistant", "Reply", provider_origin=upper_identity)
+        self.assertEqual(items, [{"kind": "assistant", "text": "Reply", "provider_origin": identity} for identity in identities])
+        digest = self.projection["history_item_cursor_digest"]
+        self.assertEqual(len({digest(item) for item in items}), 3)
+        self.assertEqual(digest(items[0]), digest({**items[0], "text": "Another rendering"}))
+        self.assertEqual(digest(items[-1]), digest({**items[-1], "provider_origin": upper_identity}))
+
+    def test_identityless_adjacent_assistant_cannot_consume_identified_occurrence(self) -> None:
+        for identities in ((None, origin()), (origin(), None), (origin(), origin(event_id="invalid"))):
+            with self.subTest(identities=identities):
+                items = []
+                for identity in identities:
+                    self.projection["add_history_item"](items, "assistant", "Reply", provider_origin=identity)
+                self.assertEqual(len(items), 2)
+        digest = self.projection["history_item_cursor_digest"]
+        legacy = {"kind": "assistant", "text": "Reply"}
+        for identity in (origin(event_id="invalid"), origin(session_id="invalid")):
+            self.assertEqual(digest({**legacy, "provider_origin": identity}), digest(legacy))
+
+    def test_full_parser_retains_adjacent_identical_text_from_distinct_assistant_ids(self) -> None:
+        events = [source_event("assistant", "Reply"), source_event("assistant", "Reply", uuid=PARENT_ID)]
+        items = self.projection["parse_claude_history_events"](events, 2)
+        self.assertEqual([item["provider_origin"]["event_id"] for item in items], [EVENT_ID, PARENT_ID])
 
     def test_full_parser_retains_first_duplicate_provenance(self) -> None:
         events = [source_event(), source_event(uuid=PARENT_ID), source_event("assistant", "Reply", uuid=PROMPT_ID)]
@@ -144,7 +184,7 @@ class ClaudeHistoryProvenanceTests(unittest.TestCase):
         self.assertEqual(items[0]["provider_origin"], origin())
         self.assertEqual(items[1]["provider_origin"]["event_id"], PROMPT_ID)
 
-    def test_delta_retains_provenance_and_keeps_kind_text_cursor_dedup(self) -> None:
+    def test_delta_retains_provenance_and_keeps_user_kind_text_cursor_dedup(self) -> None:
         first = self.projection["claude_history_event_item"](source_event())
         self.projection["bounded_jsonl_records_range"] = Mock(return_value=iter([
             (source_event(uuid=PARENT_ID), 10),
@@ -158,7 +198,36 @@ class ClaudeHistoryProvenanceTests(unittest.TestCase):
         self.assertEqual(items[0]["provider_origin"]["event_id"], PROMPT_ID)
         self.assertEqual(offset, 20)
         self.assertFalse(blocked)
-        self.assertEqual(digest, self.projection["history_item_cursor_digest"]({"kind": "assistant", "text": "Reply"}))
+        self.assertEqual(digest, self.projection["history_item_cursor_digest"](items[0]))
+
+    def test_delta_distinguishes_same_text_assistant_occurrences_across_cursor(self) -> None:
+        first = self.projection["claude_history_event_item"](source_event("assistant", "Reply"))
+        following = source_event("assistant", "Reply", uuid=PARENT_ID)
+        self.projection["bounded_jsonl_records_range"] = Mock(return_value=iter([
+            (source_event("assistant", "Reply"), 10), (following, 20), (following, 30),
+        ]))
+        items, offset, digest, blocked = self.projection["parse_provider_history_delta"](
+            Path("unused.jsonl"), "claude", 0, 30, limit=2, expected_stat={},
+            previous_last_item_digest=self.projection["history_item_cursor_digest"](first),
+        )
+        self.assertEqual([item["provider_origin"]["event_id"] for item in items], [PARENT_ID])
+        self.assertEqual(offset, 30)
+        self.assertFalse(blocked)
+        self.assertEqual(digest, self.projection["history_item_cursor_digest"](items[0]))
+
+    def test_legacy_text_cursor_conservatively_retains_identified_boundary_reply(self) -> None:
+        self.projection["bounded_jsonl_records_range"] = Mock(return_value=iter([
+            (source_event("assistant", "Reply"), 10),
+        ]))
+        legacy_digest = hashlib.sha256(b'["assistant","Reply"]').hexdigest()
+        items, offset, digest, blocked = self.projection["parse_provider_history_delta"](
+            Path("unused.jsonl"), "claude", 0, 10, limit=2, expected_stat={},
+            previous_last_item_digest=legacy_digest,
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(offset, 10)
+        self.assertFalse(blocked)
+        self.assertNotEqual(digest, legacy_digest)
 
     def test_content_reconciliation_retains_unmatched_item_metadata(self) -> None:
         items = [self.projection["claude_history_event_item"](source_event()), self.projection["claude_history_event_item"](source_event("assistant", "Reply"))]

--- a/test_codex_history_metadata_isolated.py
+++ b/test_codex_history_metadata_isolated.py
@@ -28,12 +28,15 @@ def projection():
     names = {
         "normalized_history_sync_cursor", "load_provider_history_with_cursor",
         "history_dedup_key", "history_timeline_message_keys", "is_native_goal_steer_event",
+        "history_message_match_details", "history_messages_match", "history_message_match_tokens", "clean_assistant_text",
         "reconcile_cursor_history_items", "unsynced_history_items",
         "append_durable_event_batch_sync", "append_imported_events_sync",
     }
     tree = ast.parse(SOURCE.read_text(encoding="utf-8"), filename=str(SOURCE))
     selected = [node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in names]
     assert {node.name for node in selected} == names
+    selected += [node for node in tree.body if isinstance(node, ast.Assign)
+                 and any(isinstance(target, ast.Name) and target.id == "LEADING_DECORATION_RE" for target in node.targets)]
     module = ast.fix_missing_locations(ast.Module(body=[ast.ImportFrom(
         module="__future__", names=[ast.alias(name="annotations")], level=0,
     ), *selected], type_ignores=[]))

--- a/test_provider_history_sync.py
+++ b/test_provider_history_sync.py
@@ -117,6 +117,7 @@ def fake_history_timeline_scan(events: list[dict]):
         timeline_through_seq,
         tail,
         include_imported,
+        message_details=None,
     ):
         selected = []
         has_messages = False
@@ -149,6 +150,11 @@ def fake_history_timeline_scan(events: list[dict]):
             has_messages = True
             if not include_imported and event.get("imported") is True:
                 continue
+            if message_details is not None:
+                text = event.get("prompt") if key[0] == "user" else event.get(
+                    "result_text" if event_type in {"turn_finished", "job_summary"} else "text"
+                )
+                message_details[seq] = agent_server.history_message_match_details(key[0], text, event)
             selected.append((seq, key))
         maximum = max(1, int(agent_server.HISTORY_SYNC_EVENT_SCAN_LIMIT))
         if tail:
@@ -1026,6 +1032,147 @@ class UnsyncedHistoryItemsTests(unittest.TestCase):
 
         self.assertEqual(unchanged, [])
         self.assertEqual(fresh, appended)
+
+
+class ClaudeHistoryMessageIdentityTests(unittest.TestCase):
+    provider_id = "11111111-1111-4111-8111-111111111111"
+    message_id = "22222222-2222-4222-8222-222222222222"
+    later_id = "33333333-3333-4333-8333-333333333333"
+    raw_text = "✅ **上线了**\n\nThe server is ready."
+
+    def setUp(self):
+        folder = tempfile.TemporaryDirectory(prefix="claude-history-identity-")
+        self.addCleanup(folder.cleanup)
+        self.event_path = Path(folder.name) / "events.jsonl"
+        patcher = patch.object(agent_server, "events_path", return_value=self.event_path)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def write(self, events):
+        self.events = [{"seq": index, "run_id": "run_live", **event} for index, event in enumerate(events, 1)]
+        self.event_path.write_text("".join(json.dumps(event) + "\n" for event in self.events), encoding="utf-8")
+
+    def source(self, text=None, message_id=None, provider_id=None):
+        return agent_server.claude_history_event_item({
+            "type": "assistant", "uuid": message_id or self.message_id,
+            "sessionId": provider_id or self.provider_id,
+            "message": {"content": [{"type": "text", "text": text or self.raw_text}]},
+        })
+
+    def live(self, *, identity=True, blocks=None):
+        text = agent_server.clean_assistant_text(self.raw_text)
+        parts = blocks or [text]
+        self.write([
+            {"type": "turn_started", "backend": "claude", "prompt": "Publish it"},
+            {"type": "provider_session", "backend": "claude", "provider_session_id": self.provider_id},
+            *[{"type": "reasoning_summary", "backend": "claude", "phase": "commentary", "text": part,
+               **({"provider_message_id": self.message_id} if identity else {})} for part in parts],
+            {"type": "tool_finished"},
+            {"type": "assistant_text", "text": "\n\n".join(parts)},
+            {"type": "turn_finished", "backend": "claude", "result_text": "\n\n".join(parts),
+             "provider_session_id": self.provider_id},
+        ])
+
+    def cursor(self, items, after=1):
+        return agent_server.reconcile_cursor_history_items(
+            "test-chat", items, timeline_after_seq=after, timeline_through_seq=len(self.events),
+        )
+
+    def initial(self, items):
+        return agent_server.unsynced_history_items("test-chat", items, timeline_through_seq=len(self.events))
+
+    def test_decorated_reply_is_owned_in_initial_and_cursor_sync(self):
+        self.live()
+        item = self.source()
+        self.assertEqual(self.initial([user("Publish it"), item]), [])
+        self.assertEqual(self.cursor([item]), ([], len(self.events)))
+        self.assertEqual(item["text"], self.raw_text)  # matching never rewrites presentation
+
+    def test_same_uuid_wins_over_rendering_and_preserves_later_distinct_reply(self):
+        self.live()
+        owned = self.source("Provider rendering differs beyond decorations")
+        external = self.source(message_id=self.later_id)
+        self.assertEqual(self.cursor([owned, external]), ([external], len(self.events)))
+        self.assertEqual(self.initial([user("Publish it"), owned, external]), [external])
+
+    def test_reverse_anchor_prefers_uuid_and_not_newer_same_text(self):
+        self.live()
+        owned = self.source()
+        external = self.source(message_id=self.later_id)
+        self.assertEqual(self.initial([user("Older unmatched question"), owned, external]), [external])
+
+    def test_conflicting_message_or_provider_identity_never_uses_text_fallback(self):
+        self.live()
+        for external in (self.source(message_id=self.later_id), self.source(provider_id=self.later_id)):
+            with self.subTest(origin=external["provider_origin"]):
+                self.assertEqual(self.cursor([external]), ([external], 1))
+                self.assertEqual(self.initial([user("Publish it"), external]), [external])
+
+    def test_legacy_cleaning_fallback_consumes_only_one_occurrence(self):
+        self.live(identity=False)
+        first, later = self.source(), self.source(message_id=self.later_id)
+        self.assertEqual(self.cursor([first, later]), ([later], len(self.events)))
+        self.assertEqual(self.initial([user("Publish it"), first, later]), [later])
+
+    def test_identityless_source_cannot_consume_known_live_message_credit(self):
+        self.live()
+        unknown = assistant(self.raw_text)
+        owned = self.source()
+        self.assertEqual(self.cursor([unknown, owned]), ([unknown], len(self.events)))
+
+    def test_multiple_text_blocks_and_final_echo_are_one_identity_credit(self):
+        self.live(blocks=["First block", "Second block"])
+        first = self.source("✅ First block\nSecond block")
+        later = self.source("✅ First block\nSecond block", message_id=self.later_id)
+        self.assertEqual(self.cursor([first, later]), ([later], len(self.events)))
+        self.assertEqual(self.initial([user("Publish it"), first, later]), [later])
+        self.assertEqual(self.initial([user("Unmatched older question"), first, later]), [later])
+
+    def test_terminal_echo_after_cursor_watermark_is_not_a_new_credit(self):
+        self.live()
+        later = self.source(message_id=self.later_id)
+        self.assertEqual(self.cursor([], after=3), ([], len(self.events)))
+        self.assertEqual(self.cursor([later], after=3), ([later], len(self.events)))
+
+    def test_front_scan_cap_keeps_next_distinct_identity_for_next_window(self):
+        self.live()
+        self.write([*self.events,
+            {"type": "reasoning_summary", "backend": "claude", "phase": "commentary", "text": "Another reply",
+             "provider_message_id": self.later_id, "run_id": "run_next"},
+        ])
+        with patch.object(agent_server, "HISTORY_SYNC_EVENT_SCAN_LIMIT", 1):
+            fresh, consumed = self.cursor([self.source()])
+            self.assertEqual(fresh, [])
+            self.assertEqual(consumed, 5)
+            self.assertEqual(self.cursor([self.source("Another reply", message_id=self.later_id)], after=consumed), ([], len(self.events)))
+
+    def test_compacted_display_prefix_is_not_canonical_fallback_proof(self):
+        self.live(identity=False)
+        external = {**self.source(), "source_text_sha256": agent_server.history_dedup_key("assistant", self.raw_text + " unseen suffix")[1]}
+        self.assertEqual(self.cursor([external]), ([external], 1))
+
+    def test_other_backend_and_user_text_do_not_gain_decoration_equivalence(self):
+        self.write([{"type": "assistant_text", "backend": "codex", "text": "Ready"}])
+        external = self.source("✅ Ready")
+        self.assertEqual(self.cursor([external], after=0), ([external], 0))
+        self.write([{"type": "turn_started", "backend": "claude", "prompt": "Ready"}])
+        self.assertEqual(self.cursor([user("✅ Ready")], after=0), ([user("✅ Ready")], 0))
+        self.write([{"type": "assistant_text", "backend": "codex", "text": "Ready",
+                     "provider_origin": self.source()["provider_origin"]}])
+        self.assertEqual(self.cursor([external], after=0), ([external], 0))
+
+    def test_existing_prune_does_not_recognize_emoji_copy_and_dry_run_is_read_only(self):
+        self.live()
+        self.write([*self.events,
+            {"type": "history_imported", "run_id": "import_fixture", "backend": "claude"},
+            {"type": "assistant_text", "run_id": "import_fixture", "backend": "claude", "imported": True,
+             "text": self.raw_text, "provider_origin": self.source()["provider_origin"]},
+            {"type": "turn_finished", "run_id": "import_fixture", "backend": "claude", "imported": True},
+        ])
+        before = self.event_path.read_bytes()
+        summary = agent_server.prune_duplicate_imported_history_sync("test-chat", dry_run=True)
+        self.assertEqual(summary["removed_events"], 0)
+        self.assertEqual(self.event_path.read_bytes(), before)
 
 
 class SyncProviderHistoryTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- Prevent a Claude reply from being re-imported when its raw transcript has leading decorative emoji that the live projection removed.
- Prefer validated provider-message identity and same-run provider-session ownership. Reject conflicting identities; use the existing assistant-text cleaning only as a conservative fallback for legacy live records.
- Count SDK text blocks and matching terminal echoes as one occurrence, including across cursor watermarks, while preserving distinct same-text replies.
- Keep scanner bookkeeping bounded and avoid matching truncated display prefixes.

## Validation

- 214 focused tests passed: 116 provider-history/hardening tests and 98 provenance, metadata, full-text, goal projection, local-import, and provider-reload tests.
- The new decorated-reply regression fails against unchanged baseline reconciliation and passes with this fix.
- Python compilation and git diff --check passed.
- Regression coverage includes repeated replies, identity/session/backend conflicts, legacy fallback, multi-block finals, cursor boundaries/caps, and truncated-source safeguards.

## Scope and existing duplicates

This is a prevention fix, not historical cleanup. No user history, Electron, or mobile files were changed, and nothing was released or deployed.

The existing prune path remains unchanged: its whitespace-only, global first-copy-wins matching does not recognize the emoji-different pair. A synthetic dry run confirms zero removals and unchanged bytes. Repairing existing copies requires a separately approved identity-scoped cleanup.